### PR TITLE
Maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/Afrolabs/afrolabs-clj</url>
     <connection>scm:git:git://github.com/Afrolabs/afrolabs-clj.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Afrolabs/afrolabs-clj.git</developerConnection>
-    <tag>dc365008ab248862a4a365ae55a560e3b1fd6151</tag>
+    <tag>39e163a944cec362ee24d3f02d7a3542f4cbc048</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -279,6 +279,11 @@
       <groupId>org.clojure</groupId>
       <artifactId>data.csv</artifactId>
       <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cnuernber</groupId>
+      <artifactId>charred</artifactId>
+      <version>1.034</version>
     </dependency>
     <dependency>
       <groupId>fipp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/Afrolabs/afrolabs-clj</url>
     <connection>scm:git:git://github.com/Afrolabs/afrolabs-clj.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Afrolabs/afrolabs-clj.git</developerConnection>
-    <tag>265e2fe4df59cbc7f3c9184e6af033a93057e3cb</tag>
+    <tag>dc365008ab248862a4a365ae55a560e3b1fd6151</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -76,17 +76,17 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.javascript</groupId>
       <artifactId>closure-compiler-unshaded</artifactId>
-      <version>v20231112</version>
+      <version>v20240317</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
-      <version>1.11.121</version>
+      <version>1.11.132</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -96,22 +96,22 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.reader</artifactId>
-      <version>1.3.7</version>
+      <version>1.4.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>9.4.53.v20231009</version>
+      <version>9.4.54.v20240208</version>
     </dependency>
     <dependency>
       <groupId>camel-snake-kebab</groupId>
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>net.cgrand</groupId>
       <artifactId>xforms</artifactId>
-      <version>0.19.5</version>
+      <version>0.19.6</version>
     </dependency>
     <dependency>
       <groupId>com.rpl</groupId>
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-core</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>metosin</groupId>
@@ -233,37 +233,42 @@
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>api</artifactId>
-      <version>0.8.686</version>
+      <version>0.8.692</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>endpoints</artifactId>
-      <version>1.1.12.626</version>
+      <version>1.1.12.682</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>sns</artifactId>
-      <version>847.2.1365.0</version>
+      <version>857.2.1574.0</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>sqs</artifactId>
-      <version>847.2.1398.0</version>
+      <version>857.2.1574.0</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>s3</artifactId>
-      <version>848.2.1413.0</version>
+      <version>868.2.1580.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cognitect.aws</groupId>
+      <artifactId>monitoring</artifactId>
+      <version>857.2.1574.0</version>
     </dependency>
     <dependency>
       <groupId>nrepl</groupId>
       <artifactId>nrepl</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.taoensso</groupId>
       <artifactId>timbre</artifactId>
-      <version>6.3.1</version>
+      <version>6.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -273,7 +278,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>data.csv</artifactId>
-      <version>1.0.1</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>fipp</groupId>
@@ -283,22 +288,22 @@
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>malli</artifactId>
-      <version>0.13.0</version>
+      <version>0.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>2.0.10</version>
+      <version>2.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
-      <version>2.0.10</version>
+      <version>2.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>2.0.10</version>
+      <version>2.0.12</version>
     </dependency>
     <dependency>
       <groupId>com.fzakaria</groupId>
@@ -308,17 +313,17 @@
     <dependency>
       <groupId>viesti</groupId>
       <artifactId>timbre-json-appender</artifactId>
-      <version>0.2.11</version>
+      <version>0.2.13</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.16.1</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.re2j</groupId>
@@ -343,12 +348,12 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.12.6</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>io.confluent.ksql</groupId>
       <artifactId>ksqldb-api-client</artifactId>
-      <version>7.5.3</version>
+      <version>7.6.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-log4j12</artifactId>
@@ -367,7 +372,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.10</version>
+      <version>2.0.12</version>
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>
@@ -377,7 +382,7 @@
     <dependency>
       <groupId>thheller</groupId>
       <artifactId>shadow-cljs</artifactId>
-      <version>2.26.2</version>
+      <version>2.28.3</version>
     </dependency>
     <dependency>
       <groupId>gsnewmark</groupId>
@@ -388,6 +393,11 @@
       <groupId>net.sekao</groupId>
       <artifactId>odoyle-rules</artifactId>
       <version>1.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.clojure-goes-fast</groupId>
+      <artifactId>clj-async-profiler</artifactId>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.clojure-goes-fast</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/Afrolabs/afrolabs-clj</url>
     <connection>scm:git:git://github.com/Afrolabs/afrolabs-clj.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Afrolabs/afrolabs-clj.git</developerConnection>
-    <tag>39e163a944cec362ee24d3f02d7a3542f4cbc048</tag>
+    <tag>8e1cc31ecf727b676a873c6cd6946880c280cda9</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -259,6 +259,11 @@
       <groupId>com.cognitect.aws</groupId>
       <artifactId>monitoring</artifactId>
       <version>857.2.1574.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cognitect.aws</groupId>
+      <artifactId>logs</artifactId>
+      <version>868.2.1584.0</version>
     </dependency>
     <dependency>
       <groupId>nrepl</groupId>

--- a/project.clj
+++ b/project.clj
@@ -105,6 +105,7 @@
 
                  ;; https://github.com/clojure/data.csv
                  [org.clojure/data.csv "1.1.0"]
+                 [com.cnuernber/charred "1.034"]
 
                  ;; fip, dependency of both malli and shadow-cljs
                  [fipp "0.6.26"]

--- a/project.clj
+++ b/project.clj
@@ -92,6 +92,7 @@
                  [com.cognitect.aws/sns "857.2.1574.0"]
                  [com.cognitect.aws/sqs "857.2.1574.0"]
                  [com.cognitect.aws/s3 "868.2.1580.0"]
+                 [com.cognitect.aws/monitoring "857.2.1574.0"]
 
                  ;; NREPL
                  [nrepl "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -93,6 +93,7 @@
                  [com.cognitect.aws/sqs "857.2.1574.0"]
                  [com.cognitect.aws/s3 "868.2.1580.0"]
                  [com.cognitect.aws/monitoring "857.2.1574.0"]
+                 [com.cognitect.aws/logs "868.2.1584.0"]
 
                  ;; NREPL
                  [nrepl "1.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -9,22 +9,22 @@
   :repositories [["confluent" "https://packages.confluent.io/maven/"]]
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :sign-releases false}]]
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [com.google.javascript/closure-compiler-unshaded "v20231112"]
-                 [org.clojure/clojurescript "1.11.121"]
+  :dependencies [[org.clojure/clojure "1.11.2"]
+                 [com.google.javascript/closure-compiler-unshaded "v20240317"]
+                 [org.clojure/clojurescript "1.11.132"]
 
                  ;; property-based testing, generative testing
                  [org.clojure/test.check "1.1.1"]
 
                  ;; dependency conflict resolution, also edn reader
-                 [org.clojure/tools.reader "1.3.7"]
+                 [org.clojure/tools.reader "1.4.1"]
 
                  ;; I'm not sure why we're choosing an old version of jetty here.
                  ;; might be cognitect.
                  ;; https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-util
-                 [org.eclipse.jetty/jetty-util "9.4.53.v20231009"]
-                 [org.eclipse.jetty/jetty-http "9.4.53.v20231009"]
-                 [org.eclipse.jetty/jetty-client "9.4.53.v20231009"]
+                 [org.eclipse.jetty/jetty-util "9.4.54.v20240208"]
+                 [org.eclipse.jetty/jetty-http "9.4.54.v20240208"]
+                 [org.eclipse.jetty/jetty-client "9.4.54.v20240208"]
 
                  ;; conversions between different kinds of casing
                  ;; camelCase -> snake_case -> kebab-case -> PascalCase
@@ -43,7 +43,7 @@
                  [org.clojure/core.async "1.6.681"]
 
                  ;; https://github.com/cgrand/xforms ; sometimes useful extra transducers - data transformation
-                 [net.cgrand/xforms "0.19.5"]
+                 [net.cgrand/xforms "0.19.6"]
 
                  ;; https://github.com/redplanetlabs/specter, data transformation DSL
                  [com.rpl/specter "1.1.4"]
@@ -67,7 +67,7 @@
                  [buddy/buddy-auth "3.0.323"]
                  [buddy/buddy-sign "3.5.351"]
 
-                 [ring/ring-core "1.11.0"]
+                 [ring/ring-core "1.12.1"]
 
                  ;; https://github.com/metosin/ring-http-response
                  ;; ring response helper fns
@@ -87,34 +87,34 @@
                  [clj-commons/iapetos "0.1.13"]
 
                  ;; cognitect (custodians of clojure) has a very nice data driven API interface to AWS
-                 [com.cognitect.aws/api "0.8.686"]
-                 [com.cognitect.aws/endpoints "1.1.12.626"]
-                 [com.cognitect.aws/sns "847.2.1365.0"]
-                 [com.cognitect.aws/sqs "847.2.1398.0"]
-                 [com.cognitect.aws/s3 "848.2.1413.0"]
+                 [com.cognitect.aws/api "0.8.692"]
+                 [com.cognitect.aws/endpoints "1.1.12.682"]
+                 [com.cognitect.aws/sns "857.2.1574.0"]
+                 [com.cognitect.aws/sqs "857.2.1574.0"]
+                 [com.cognitect.aws/s3 "868.2.1580.0"]
 
                  ;; NREPL
-                 [nrepl "1.1.0"]
+                 [nrepl "1.1.1"]
 
                  ;; logging for clj(s) https://github.com/ptaoussanis/timbre
-                 [com.taoensso/timbre "6.3.1"]
+                 [com.taoensso/timbre "6.5.0"]
 
                  ;; https://github.com/clojure/data.json
                  [org.clojure/data.json "2.5.0"]
 
                  ;; https://github.com/clojure/data.csv
-                 [org.clojure/data.csv "1.0.1"]
+                 [org.clojure/data.csv "1.1.0"]
 
                  ;; fip, dependency of both malli and shadow-cljs
                  [fipp "0.6.26"]
 
                  ;; malli; schema-driven development and utilities
-                 [metosin/malli "0.13.0"]
+                 [metosin/malli "0.15.0"]
 
                  ;; hooking in the result of other java logging frameworks into slf4j
-                 [org.slf4j/log4j-over-slf4j "2.0.10"]
-                 [org.slf4j/jul-to-slf4j "2.0.10"]
-                 [org.slf4j/jcl-over-slf4j "2.0.10"]
+                 [org.slf4j/log4j-over-slf4j "2.0.12"]
+                 [org.slf4j/jul-to-slf4j "2.0.12"]
+                 [org.slf4j/jcl-over-slf4j "2.0.12"]
 
                  ;; then routing slf4j to timbre
                  ;; This will allow us to receive, log (and configure) the logs provided by libraries
@@ -122,10 +122,10 @@
                  [com.fzakaria/slf4j-timbre "0.4.1"]
 
                  ;; possibility to log to json, for use in cloud environments like GCK
-                 [viesti/timbre-json-appender "0.2.11"]
+                 [viesti/timbre-json-appender "0.2.13"]
 
-                 [com.fasterxml.jackson.core/jackson-databind "2.16.1"]
-                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.16.1"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.17.0"]
+                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.17.0"]
 
 
                  ;; https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
@@ -145,7 +145,7 @@
 
                  ;; dependency issue resolutions brought on by confluent
                  ;; [jakarta.xml.bind/jakarta.xml.bind-api "2.3.3" :upgrade false]
-                 [joda-time "2.12.6"]
+                 [joda-time "2.12.7"]
 
                  ;; dependencies for confluent cloud
                  ;; [org.apache.kafka/connect-runtime "3.6.1" :exclusions [org.slf4j/slf4j-log4j12]]
@@ -154,22 +154,26 @@
                  ;;                                                                 org.glassfish.jersey.core/jersey-common]]
 
                  ;; for use with ksqld, the java client
-                 [io.confluent.ksql/ksqldb-api-client "7.5.3" :exclusions [org.slf4j/slf4j-log4j12
+                 [io.confluent.ksql/ksqldb-api-client "7.6.0" :exclusions [org.slf4j/slf4j-log4j12
                                                                            org.bouncycastle/bc-fips
                                                                            org.javassist/javassist]]
 
-                 [org.slf4j/slf4j-api "2.0.10"]
+                 [org.slf4j/slf4j-api "2.0.12"]
                  ;; [org.slf4j/slf4j-log4j12 "1.7.32"]
                  [io.confluent/confluent-log4j "1.2.17-cp5"]
 
                  
-                 [thheller/shadow-cljs "2.26.2"]
+                 [thheller/shadow-cljs "2.28.3"]
 
                  ;; middleware that adds "X-Clacks-Overhead" to responses
                  [gsnewmark/ring-pratchett "0.1.0"]
 
                  ;; rules engine
                  [net.sekao/odoyle-rules "1.3.1"]
+
+                 ;; profiling
+                 ;; this is safe to distribute into prod according to the docs
+                 [com.clojure-goes-fast/clj-async-profiler "1.2.0"]
 
                  ]
   :aot [afrolabs.components.kafka.json-serdes

--- a/src/afrolabs/aws/cloudwatch_logs.clj
+++ b/src/afrolabs/aws/cloudwatch_logs.clj
@@ -81,9 +81,9 @@
                         (if-not (< max-message-size msg-size')
                           [msg-size' (:message log-event')]
                           (do
-                            (log/debugf "Attempt to log a message that has size (%d) which is larger than the max-message-size (%d). Message truncated."
-                                        msg-size'
-                                        max-message-size)
+                            (log/warnf "Attempt to log a message that has size (%d) which is larger than the max-message-size (%d). Message truncated."
+                                       msg-size'
+                                       max-message-size)
                             [max-message-size
                              (String. (into-array Byte/TYPE (take max-message-size msg-bytes)))]))
 

--- a/src/afrolabs/components/aws.clj
+++ b/src/afrolabs/components/aws.clj
@@ -1,10 +1,8 @@
 (ns afrolabs.components.aws
   (:require
    [afrolabs.components :as -comp]
-   [afrolabs.components.aws.sso :as -aws-sso-profile-provider]
    [clojure.core.async :as csp]
    [clojure.spec.alpha :as s]
-   [cognitect.aws.client.api :as aws]
    [cognitect.aws.credentials :as aws-creds]
    [taoensso.timbre :as log]
    ))
@@ -138,45 +136,3 @@
 ;; _except_ the :api <api-name> values.
 ;; The idea is that you have one (hopufully) such component in your integrant config
 ;; and then re-use this by adding :api <api-name> to the result, and passing that to (aws/client ...)
-
-(s/def ::profile string?)
-(s/def ::aws-client-config-cfg
-  (s/keys :req-un [::access-key-id
-                   ::secret-access-key
-                   ::region
-                   ::profile]))
-
-(defn make-aws-client
-  [{:keys [region
-           access-key-id
-           secret-access-key
-           profile]
-    :as _cfg}]
-
-  (cond-> {}
-    region
-    (assoc :region region)
-
-    (and access-key-id
-         secret-access-key)
-    (assoc :credentials-provider
-           (aws-creds/basic-credentials-provider
-            {:access-key-id     access-key-id
-             :secret-access-key secret-access-key}))
-
-    (not (and access-key-id
-              secret-access-key))
-    (assoc :credentials-provider
-           (aws-creds/chain-credentials-provider
-            [(aws-creds/default-credentials-provider (aws/default-http-client))
-             ;; this crazy shit provides a work-around because
-             ;; cognitect's profile credentials provider does not work for sso.
-             ;; We are adding it at the end of the chain.
-             (-aws-sso-profile-provider/provider (or profile
-                                                     (System/getenv "AWS_PROFILE")
-                                                     (System/getProperty "aws.profile")
-                                                     "default"))]))))
-
-(-comp/defcomponent {::-comp/ig-kw       ::aws-client-config
-                     ::-comp/config-spec ::aws-client-config-cfg}
-  [cfg] (make-aws-client cfg))

--- a/src/afrolabs/components/aws/client_config.clj
+++ b/src/afrolabs/components/aws/client_config.clj
@@ -1,0 +1,53 @@
+(ns afrolabs.components.aws.client-config
+  (:require
+   [afrolabs.components :as -comp]
+   [afrolabs.components.aws.sso :as -aws-sso-profile-provider]
+   [clojure.spec.alpha :as s]
+   [cognitect.aws.client.api :as aws]
+   [cognitect.aws.credentials :as aws-creds]
+   ))
+
+(s/def ::profile string?)
+(s/def ::access-key-id (s/nilable string?))
+(s/def ::secret-access-key (s/nilable string?))
+(s/def ::region (s/nilable string?))
+(s/def ::aws-client-config-cfg
+  (s/keys :req-un [::access-key-id
+                   ::secret-access-key
+                   ::region]
+          :opt-un [::profile]))
+
+(defn make-aws-client
+  [{:keys [region
+           access-key-id
+           secret-access-key
+           profile]
+    :as _cfg}]
+
+  (cond-> {}
+    region
+    (assoc :region region)
+
+    (and access-key-id
+         secret-access-key)
+    (assoc :credentials-provider
+           (aws-creds/basic-credentials-provider
+            {:access-key-id     access-key-id
+             :secret-access-key secret-access-key}))
+
+    (not (and access-key-id
+              secret-access-key))
+    (assoc :credentials-provider
+           (aws-creds/chain-credentials-provider
+            [(aws-creds/default-credentials-provider (aws/default-http-client))
+             ;; this crazy shit provides a work-around because
+             ;; cognitect's profile credentials provider does not work for sso.
+             ;; We are adding it at the end of the chain.
+             (-aws-sso-profile-provider/provider (or profile
+                                                     (System/getenv "AWS_PROFILE")
+                                                     (System/getProperty "aws.profile")
+                                                     "default"))]))))
+
+(-comp/defcomponent {::-comp/ig-kw       ::aws-client-config
+                     ::-comp/config-spec ::aws-client-config-cfg}
+  [cfg] (make-aws-client cfg))

--- a/src/afrolabs/components/cloudwatch_logs.clj
+++ b/src/afrolabs/components/cloudwatch_logs.clj
@@ -1,0 +1,237 @@
+(ns afrolabs.components.cloudwatch-logs
+  "Exports a component for integration with timbre that exports logs to cloudwatch. "
+  (:require
+   [afrolabs.components.aws.sso :as -aws-sso-profile-provider]
+   [afrolabs.spec :as -spec]
+   [clojure.core.async :as csp]
+   [clojure.data.json :as json]
+   [clojure.spec.alpha :as s]
+   [cognitect.aws.client.api :as aws]
+   [cognitect.aws.credentials :as aws-creds]
+   [integrant.core :as ig]
+   [java-time :as t]
+   [taoensso.timbre :as log]
+   [timbre-json-appender.core]
+   ))
+
+(comment
+
+  (def cloudwatch
+    (aws/client {:api                  :logs
+                 :credentials-provider (-aws-sso-profile-provider/provider "AdministratorAccess-381491896970-GoMetro-Bridge-Dev")
+                 :region               "af-south-1"}))
+  (sort (keys (aws/ops cloudwatch)))
+
+  (aws/doc cloudwatch :CreateLogStream)
+  (aws/doc cloudwatch :PutLogEvents)
+
+
+  )
+
+(defn create-log-stream
+  [client group stream]
+  (aws/invoke client
+              {:op      :CreateLogStream
+               :request {:logGroupName  group
+                         :logStreamName stream}}))
+
+(defn put-log-events
+  [client group stream log-events]
+  (aws/invoke client
+              {:op      :PutLogEvents
+               :request {:logGroupName  group
+                         :logStreamName stream
+                         :logEvents     log-events}}))
+
+(comment
+
+  (create-log-stream cloudwatch "pieter-test" "test-1")
+  (put-log-events cloudwatch "pieter-test" "test-1" [{:timestamp (.toEpochMilli ^java.time.Instant (t/instant))
+                                                      :message (json/write-str {:hello "world"})}
+                                                     {:timestamp (.toEpochMilli ^java.time.Instant (t/instant))
+                                                      :message (json/write-str {:my "name"})}
+                                                     {:timestamp (.toEpochMilli ^java.time.Instant (t/instant))
+                                                      :message (json/write-str {:is "pieter"})}])
+
+  )
+
+;; from https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
+(def ^:const max-payload-size 1045576)
+(def ^:const max-messages-per-payload 10000)
+(def ^:const max-message-size (* 256 1024))
+
+;; we will batch the messages for the cloudwatch limits
+;; - max batch size is 1 045 576 bytes, which is UTF8 of the message + 26 bytes per message
+;; - max of 10 000 messages per batch
+(defn make-batches
+  [log-events]
+  (let [{:keys [current-batch
+                earlier-batches]}
+        (reduce (fn [acc log-event']
+                  (let [msg-bytes (.getBytes ^String (:message log-event') "UTF-8")
+                        msg-size' (count msg-bytes)
+
+                        [msg-size actual-message]
+                        (if-not (< max-message-size msg-size')
+                          [msg-size' (:message log-event')]
+                          (do
+                            (log/debugf "Attempt to log a message that has size (%d) which is larger than the max-message-size (%d). Message truncated."
+                                        msg-size'
+                                        max-message-size)
+                            [max-message-size
+                             (String. (into-array Byte/TYPE (take max-message-size msg-bytes)))]))
+
+                        log-event (assoc log-event' :message actual-message)]
+                    (if (or
+                         ;; will the new message push the current batch over the payload size limit?
+                         (<= max-payload-size
+                             (+ (:current-batch-payload-size acc)
+                                (+ 26 msg-size)))
+                         ;; is this the max-messages-per-payload-th message in this batch?
+                         (= max-messages-per-payload
+                            (count (:current-batch acc))))
+                      {:current-batch              [log-event]
+                       :current-batch-payload-size (+ 26 msg-size)
+                       :earlier-batches            (conj (:earlier-batches acc)
+                                                         (:current-batch acc))}
+                      (-> acc
+                          (update :current-batch conj log-event)
+                          (update :current-batch-payload-size + 26 msg-size)))))
+                {:current-batch              []
+                 :current-batch-payload-size 0
+                 :earlier-batches            []}
+                log-events)]
+    (conj earlier-batches current-batch)))
+
+(defn create-log-dispatcher
+  "Returns a function, that accepts a single log-event.
+  This log-event will be batched with others and uploaded to cloudwatch every batch-period ms.
+  When called with `:stop` as a paremeter, will stop the internal thread and therefore stop uploading logs.
+  Each log-event must have a string :message and :timestamp with epoch-ms."
+  [client group stream & {:as   _opts
+                          :keys [batch-period-ms]
+                          :or   {batch-period-ms 1000}}]
+  (let [enqued-log-events (atom [])
+        stop-signal (csp/chan)]
+
+    (csp/thread
+      (loop [to (csp/timeout batch-period-ms)]
+        ;; do uploading
+        (let [[msgs _] (swap-vals! enqued-log-events (constantly []))
+              batches (make-batches msgs)]
+          (doseq [batch batches]
+            (put-log-events client group stream batch)))
+        ;; wait for batch-period of time, or until we receive the signal to stop
+        (let [[_ ch] (csp/alts!! [stop-signal to])]
+          (when-not (= ch stop-signal)
+            (recur (csp/timeout batch-period-ms)))))
+      (log/debug "Done with aws cloudwatch log dispatcher thread."))
+
+
+    (fn [log-event]
+      (if (not= log-event :stop)
+        (swap! enqued-log-events conj log-event)
+        (csp/close! stop-signal)))))
+
+(comment
+
+  (def stop
+    (let [stop? (atom false)]
+      (csp/thread
+        (let [dispatch-log (create-log-dispatcher cloudwatch "pieter-test" "test-1")]
+          (loop [x 0]
+            (Thread/sleep 100)
+            (dispatch-log {:message   (str "testing 2: " x)
+                           :timestamp (.toEpochMilli ^java.time.Instant (t/instant))})
+            (when (not @stop?)
+              (recur (inc x))))
+          (dispatch-log :stop)))
+      (fn [] (reset! stop? true))))
+  (stop)
+
+  )
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; component
+;;
+;; There is probably no need to have more than once of this component, so no -comp/defcomponent for this one.
+
+(s/def ::non-empty-string (s/and string?
+                                 #(pos? (count %))))
+(s/def ::log-group ::non-empty-string)
+(s/def ::log-stream ::non-empty-string)
+(s/def ::create-log-stream? boolean?)
+(s/def ::disabled? boolean?)
+(s/def ::aws-region ::non-empty-string)
+(s/def ::aws-access-key-id (s/nilable ::non-empty-string))
+(s/def ::aws-secret-access-key (s/nilable ::non-empty-string))
+
+(s/def ::install-timbre-appender-cfg
+  (s/keys :req-un [::log-group
+                   ::log-stream
+                   ::create-log-stream?
+                   ::disabled?]
+          :opt-un [::aws-access-key-id
+                   ::aws-secret-access-key
+                   ::aws-region]))
+
+(defmethod ig/init-key ::install-timbre-appender
+  [_ cfg]
+  (-spec/assert! ::install-timbre-appender-cfg cfg)
+  (let [{:keys [log-group
+                log-stream
+                create-log-stream?
+                disabled?
+                aws-region
+                aws-access-key-id
+                aws-secret-access-key]} cfg]
+    (if disabled?
+      {:dispatch-fn (constantly nil)}
+      (let [client-cfg (cond-> {:api    :logs
+                                :region aws-region}
+
+                         (and aws-access-key-id
+                              aws-secret-access-key)
+                         (assoc :credentials-provider
+                                (aws-creds/basic-credentials-provider
+                                 {:access-key-id     aws-access-key-id
+                                  :secret-access-key aws-secret-access-key}))
+
+                         (not (and aws-access-key-id
+                                   aws-secret-access-key))
+                         (assoc :credentials-provider
+                                (aws-creds/chain-credentials-provider
+                                 [(aws-creds/default-credentials-provider (aws/default-http-client))
+                                  ;; this crazy shit provides a work-around because
+                                  ;; cognitect's profile credentials provider does not work for sso.
+                                  ;; We are adding it at the end of the chain.
+                                  (-aws-sso-profile-provider/provider (or (System/getenv "AWS_PROFILE")
+                                                                          (System/getProperty "aws.profile")
+                                                                          "default"))])))
+            client (aws/client client-cfg)
+            _ (when create-log-stream? (create-log-stream client log-group log-stream))
+            dispatch-fn (create-log-dispatcher client log-group log-stream)]
+
+        (log/merge-config! {:appenders {:aws {:enabled?  true
+                                              :async?    false
+                                              :min-level nil
+                                              :output-fn (timbre-json-appender.core/make-json-output-fn {})
+                                              :fn        (fn [{:keys [output_ ^java.util.Date instant]}]
+                                                           (dispatch-fn {:message   output_
+                                                                         :timestamp (.getTime instant)}))}}})
+        (assoc cfg :dispatch-fn dispatch-fn)))))
+
+(defmethod ig/halt-key! ::install-timbre-appender
+  [_ {:as _state
+      :keys [dispatch-fn]}]
+  (dispatch-fn :stop)
+  (log/merge-config! {:appenders {:aws nil}}))
+
+(comment
+
+  (def system (ig/init {::install-timbre-appender {:log-group "pieter-test"
+                                                   :log-stream "test-2"
+                                                   :create-log-stream? true
+                                                   :disabled? false
+                                                   :aws-region "af-south-1"}}))
+  )

--- a/src/afrolabs/components/http.clj
+++ b/src/afrolabs/components/http.clj
@@ -63,7 +63,7 @@
     (let [request-id (random-uuid)]
       (log/with-context+ {:request-id request-id}
         (http-response/header (handler req)
-                              "X-RequestId" (str request-id))))))
+                              "X-Request-Id" (str request-id))))))
 
 (defn basic-request-logging
   [handler {:as logging-context

--- a/src/afrolabs/components/http.clj
+++ b/src/afrolabs/components/http.clj
@@ -62,7 +62,8 @@
   (fn [req]
     (let [request-id (random-uuid)]
       (log/with-context+ {:request-id request-id}
-        (handler req)))))
+        (http-response/header (handler req)
+                              "X-RequestId" (str request-id))))))
 
 (defn basic-request-logging
   [handler {:as logging-context

--- a/src/afrolabs/components/http.clj
+++ b/src/afrolabs/components/http.clj
@@ -57,6 +57,23 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn add-request-id
+  [handler]
+  (fn [req]
+    (let [request-id (random-uuid)]
+      (log/with-context+ {:request-id request-id}
+        (handler req)))))
+
+(defn basic-request-logging
+  [handler logging-context]
+  (fn [{:as req
+        :keys [uri]}]
+    (let [{:as   res
+           :keys [status]} (log/with-context+ logging-context
+                             (handler req))]
+      (log/debug (format "%s - %d" uri status))
+      res)))
+
 (defn create-http-component
   [{:keys [port
            ip
@@ -81,6 +98,8 @@
                              identity)
         handler' (-> handler
                      (middleware-chain)
+                     (basic-request-logging {:port port :ip ip})
+                     (add-request-id)
                      (ring.middleware.pratchett/wrap-pratchett))
         s (httpkit/run-server handler'
                               {:worker-name-prefix   worker-thread-name-prefix
@@ -92,7 +111,7 @@
                                                        (if-not ex
                                                          (log/warn txt)
                                                          (log/warn ex txt)))
-                               :event-logger         (fn [event-name] (log/debug event-name))
+                               ;; :event-logger         (fn [event-name] (log/debug event-name)) ;; replaced with (basic-request-logging)
                                :legacy-return-value? false
                                :port                 port
                                :ip                   ip})]

--- a/src/afrolabs/components/http.clj
+++ b/src/afrolabs/components/http.clj
@@ -65,13 +65,14 @@
         (handler req)))))
 
 (defn basic-request-logging
-  [handler logging-context]
+  [handler {:as logging-context
+            :keys [port ip]}]
   (fn [{:as req
         :keys [uri]}]
     (let [{:as   res
            :keys [status]} (log/with-context+ logging-context
                              (handler req))]
-      (log/debug (format "%s - %d" uri status))
+      (log/debug (str ip ":" port uri " [" status "]"))
       res)))
 
 (defn create-http-component

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1102,7 +1102,8 @@
   (let [consumer-group-id (get consumer-properties ConsumerConfig/GROUP_ID_CONFIG "<UNAVAILABLE>")]
     (csp/go
       (let [[status xtra :as thread-result]
-            (csp/<! (csp/thread (log/with-context+ {:consumer-group-id consumer-group-id}
+            (csp/<! (csp/thread (log/with-context+ {:consumer-group-id consumer-group-id
+                                                    :consume-id        (random-uuid)}
                                   (-consumer-main consumer
                                                   must-stop
                                                   :consumer-config consumer-config

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1083,13 +1083,13 @@
                         strategies)]
         (shutdown-hook s consumer))
 
-      ;; close the consumer. this commits and exits cleanly
-      (.close consumer)
-
       ;; the value we are returning
       [:done true]
       (catch Throwable t
-        [:error t]))))
+        [:error t])
+      (finally
+        ;; close the consumer. this commits and exits cleanly
+        (.close consumer)))))
 
 (defn- background-wait-on-stop-signal
   "Extracted only because the debugger chokes on core.async."

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1410,7 +1410,18 @@
 
       IDeref
       (deref [_]
-        @has-caught-up-once
+        ;; wait, but with feedback every 5 seconds
+        (let [starting-millis (System/currentTimeMillis)]
+          (loop []
+            (let [caught-up? (deref has-caught-up-once
+                                    5000
+                                    :timeout)]
+              (when (= :timeout caught-up?)
+                (log/info (str "KTable '" consumer-group-id "' loading initial data. Waited "
+                               (long (/ (- (System/currentTimeMillis) starting-millis)
+                                        1000))
+                               " seconds so far."))
+                (recur)))))
         @ktable-state)
 
       IBlockingDeref

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -157,11 +157,16 @@
         (csp/close! delivered-ch)
         (trace "onCompletion done.")))))
 
+(-prom/register-metric (prom/counter ::producer-msgs-produced
+                                     {:description "How many messages are being produce via producer-produce."
+                                      :labels [:topic]}))
+
 (defn- producer-produce
   [^Producer producer msgs]
   (s/assert :producer/msgs msgs)
   (doseq [{:as msg
            :keys [delivered-ch]} msgs]
+    (prom/inc (get-counter-producer-msgs-produced {:topic (:topic msg)}))
     (let [producer-record (ProducerRecord. (:topic msg)
                                            (when-let [p (:partition msg)] p)
                                            nil ;; timestamp, Long

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1066,8 +1066,8 @@
                                                            (= (:topic %) topic))
                                                      end-offsets)))]]
                     (prom/set (get-gauge-consumer-partition-lag {:consumer-group-id consumer-group-id
-                                                                 :partition         partition
-                                                                 :offset            offset})
+                                                                 :topic             topic
+                                                                 :partition         partition})
                               (- end-offset offset)))
 
                 _ (prom/inc (get-counter-consumer-poll {:consumer-group-id consumer-group-id}))

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1067,8 +1067,8 @@
                                                      end-offsets)))]]
                     (prom/set (get-gauge-consumer-partition-lag {:consumer-group-id consumer-group-id
                                                                  :partition         partition
-                                                                 :offset            offset}
-                                                                (- end-offset offset))))
+                                                                 :offset            offset})
+                              (- end-offset offset)))
 
                 _ (prom/inc (get-counter-consumer-poll {:consumer-group-id consumer-group-id}))
                 ;; register prometheus metrics for msgs consumed per topic

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -166,7 +166,9 @@
   (s/assert :producer/msgs msgs)
   (doseq [{:as msg
            :keys [delivered-ch]} msgs]
-    (prom/inc (get-counter-producer-msgs-produced {:topic (:topic msg)}))
+    (prom/inc (get-counter-producer-msgs-produced {:topic (:topic msg)})
+              1)
+
     (let [producer-record (ProducerRecord. (:topic msg)
                                            (when-let [p (:partition msg)] p)
                                            nil ;; timestamp, Long

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1045,7 +1045,7 @@
 
       (combined-post-init-hooks consumer)
 
-      (let [consumer-group-id (.groupId (.groupMetaData  consumer))]
+      (let [consumer-group-id (.groupId (.groupMetadata ^Consumer consumer))]
 
         (while (not @must-stop)
           (let [consumed-records           (into []

--- a/src/afrolabs/components/kafka/bytes_serdes.clj
+++ b/src/afrolabs/components/kafka/bytes_serdes.clj
@@ -50,7 +50,7 @@
   ([_ _ ^ByteBuffer byte-data]
    (when byte-data
      (let [result (make-array Byte/TYPE (.remaining byte-data))]
-       (.get byte-data result)
+       (.get byte-data ^bytes result)
        result)))
   ([this _ _ byte-data]
    (deser-deserialize-String-Headers-ByteBuffer this nil byte-data)))

--- a/src/afrolabs/components/kafka/bytes_serdes.clj
+++ b/src/afrolabs/components/kafka/bytes_serdes.clj
@@ -4,7 +4,8 @@
   (:import [org.apache.kafka.common.header Headers]
            [afrolabs.components.kafka IUpdateConsumerConfigHook IUpdateProducerConfigHook]
            [org.apache.kafka.clients.consumer ConsumerConfig]
-           [org.apache.kafka.clients.producer ProducerConfig]))
+           [org.apache.kafka.clients.producer ProducerConfig]
+           [java.nio ByteBuffer]))
 
 (comment
 
@@ -37,13 +38,22 @@
            :main false
            :implements [org.apache.kafka.common.serialization.Deserializer])
 
-(defn deser-deserialize
-  ([_ _ byte-data]
+(defn deser-deserialize-String-Headers-byte<>
+  ([_ _ ^bytes byte-data]
    (when byte-data
      (java.util.Arrays/copyOf ^bytes byte-data
                               (alength ^bytes byte-data))))
+  ([this _ _ ^bytes byte-data]
+   (deser-deserialize-String-Headers-bytes this nil byte-data)))
+
+(defn deser-deserialize-String-Headers-ByteBuffer
+  ([_ _ ^ByteBuffer byte-data]
+   (when byte-data
+     (let [result (make-array Byte/TYPE (.remaining byte-data))]
+       (.get byte-data result)
+       result)))
   ([this _ _ byte-data]
-   (deser-deserialize this nil byte-data)))
+   (deser-deserialize-String-Headers-ByteBuffer this nil byte-data)))
 
 (defn deser-close [_])
 (defn deser-configure [_ _ _])

--- a/src/afrolabs/components/kafka/bytes_serdes.clj
+++ b/src/afrolabs/components/kafka/bytes_serdes.clj
@@ -44,7 +44,7 @@
      (java.util.Arrays/copyOf ^bytes byte-data
                               (alength ^bytes byte-data))))
   ([this _ _ ^bytes byte-data]
-   (deser-deserialize-String-Headers-bytes this nil byte-data)))
+   (deser-deserialize-String-Headers-byte<> this nil byte-data)))
 
 (defn deser-deserialize-String-Headers-ByteBuffer
   ([_ _ ^ByteBuffer byte-data]

--- a/src/afrolabs/components/kafka/edn_serdes.clj
+++ b/src/afrolabs/components/kafka/edn_serdes.clj
@@ -5,7 +5,9 @@
   (:require [clojure.tools.reader.edn :as edn]
             [taoensso.timbre :as log]
             [java-time :as t])
-  (:import [org.apache.kafka.common.header Headers]))
+  (:import
+   [org.apache.kafka.common.header Headers]
+   [java.nio ByteBuffer]))
 
 (gen-class :name "afrolabs.components.kafka.edn_serdes.Serializer"
            :prefix "ser-"
@@ -37,17 +39,31 @@
 (defn deser-init []
   [[] (atom nil)])
 
-(defn deser-deserialize
-  ([this topic byte-data]
+(defn deser-deserialize-String-Headers-byte<>
+  ([this topic ^bytes byte-data]
    (when byte-data
      (try (edn/read-string @(.state this)
-                           (String. ^bytes byte-data))
+                           (String. byte-data))
           (catch Throwable t
             (log/error t (str "Unable to deserialize EDN from topic '" topic "'.\n"
                               "The string value of the data is: \n" (String. ^bytes byte-data) "\n"
                               "The byte-array value is: " (mapv identity byte-data)))))))
   ([this _ _ byte-data]
-   (deser-deserialize this nil byte-data)))
+   (deser-deserialize-String-Headers-byte<> this nil byte-data)))
+
+(defn deser-deserialize-String-Headers-ByteBuffer
+  ([this topic ^ByteBuffer byte-data]
+   (when byte-data
+     (let [byte-array (make-array Byte/TYPE (.remaining byte-data))]
+       (.get byte-data byte-array)
+       (try (edn/read-string @(.state this)
+                             (String. ^bytes byte-array))
+            (catch Throwable t
+              (log/error t (str "Unable to deserialize EDN from topic '" topic "'.\n"
+                                "The string value of the data is: \n" (String. ^bytes byte-array) "\n"
+                                "The byte-array value is: " (mapv identity byte-array))))))))
+  ([this _ _ byte-data]
+   (deser-deserialize-String-Headers-ByteBuffer this nil byte-data)))
 
 (defn deser-close [_])
 (defn deser-configure [this config-settings _]

--- a/src/afrolabs/components/kafka/edn_serdes.clj
+++ b/src/afrolabs/components/kafka/edn_serdes.clj
@@ -9,6 +9,12 @@
    [org.apache.kafka.common.header Headers]
    [java.nio ByteBuffer]))
 
+(comment
+
+  (set! *warn-on-reflection* true)
+
+  )
+
 (gen-class :name "afrolabs.components.kafka.edn_serdes.Serializer"
            :prefix "ser-"
            :main false
@@ -42,7 +48,7 @@
 (defn deser-deserialize-String-Headers-byte<>
   ([this topic ^bytes byte-data]
    (when byte-data
-     (try (edn/read-string @(.state this)
+     (try (edn/read-string @(.state ^afrolabs.components.kafka.edn_serdes.Deserializer this)
                            (String. byte-data))
           (catch Throwable t
             (log/error t (str "Unable to deserialize EDN from topic '" topic "'.\n"
@@ -55,8 +61,8 @@
   ([this topic ^ByteBuffer byte-data]
    (when byte-data
      (let [byte-array (make-array Byte/TYPE (.remaining byte-data))]
-       (.get byte-data byte-array)
-       (try (edn/read-string @(.state this)
+       (.get byte-data ^bytes byte-array)
+       (try (edn/read-string @(.state ^afrolabs.components.kafka.edn_serdes.Deserializer this)
                              (String. ^bytes byte-array))
             (catch Throwable t
               (log/error t (str "Unable to deserialize EDN from topic '" topic "'.\n"
@@ -67,7 +73,7 @@
 
 (defn deser-close [_])
 (defn deser-configure [this config-settings _]
-  (reset! (.-state this)
+  (reset! (.-state ^afrolabs.components.kafka.edn_serdes.Deserializer this)
           {:readers (cond-> {}
                       (get config-settings (:parse-inst-as-java-time config-keys))
                       (assoc 'inst #(t/instant %)))}))

--- a/src/afrolabs/components/kafka/json_serdes.clj
+++ b/src/afrolabs/components/kafka/json_serdes.clj
@@ -78,7 +78,7 @@
        (.get byte-data ^bytes byte-array)
        (try
          ((:reader @(.state ^afrolabs.components.kafka.json_serdes.Deserializer this))
-          byte-data)
+          byte-array)
          (catch Throwable t
            (log/error t (str "Unable to json deserialize from topic '" topic "'.\n"
                              "The string value of the data is:\n" (String. ^bytes byte-array) "\n"

--- a/src/afrolabs/components/kafka/json_serdes.clj
+++ b/src/afrolabs/components/kafka/json_serdes.clj
@@ -51,7 +51,7 @@
    (when byte-data
      (try
        (json/read-str (String. ^bytes byte-data)
-                      @(.state this))
+                      @(.state ^afrolabs.components.kafka.json_serdes.Deserializer this))
        (catch Throwable t
          (log/error t (str "Unable to json deserialize from topic '" topic "'.\n"
                            "The string value of the data is:\n" (String. ^bytes byte-data) "\n"
@@ -63,10 +63,10 @@
   ([this topic ^ByteBuffer byte-data]
    (when byte-data
      (let [byte-array (make-array Byte/TYPE (.remaining byte-data))]
-       (.get byte-data byte-array)
+       (.get byte-data ^bytes byte-array)
        (try
          (json/read-str (String. ^bytes byte-array)
-                        @(.state this))
+                        @(.state ^afrolabs.components.kafka.json_serdes.Deserializer this))
          (catch Throwable t
            (log/error t (str "Unable to json deserialize from topic '" topic "'.\n"
                              "The string value of the data is:\n" (String. ^bytes byte-array) "\n"
@@ -89,7 +89,7 @@
                                                      "and this is not recognised. Using 'identity'."))
                                       identity))))]
     (log/debug (str "Setting json deserializer options to: " read-opts))
-    (reset! (.-state this) read-opts)))
+    (reset! (.-state ^afrolabs.components.kafka.json_serdes.Deserializer this) read-opts)))
 
 ;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -249,7 +249,8 @@
              topic-predicate
              preserve-internal-and-confluent-topics]
       :or {extra-strategies                       []
-           preserve-internal-and-confluent-topics true}}]
+           preserve-internal-and-confluent-topics true
+           topic-predicate                        (complement #(str/starts-with? % "_"))}}]
   (when-not preserve-internal-and-confluent-topics
     (log/warn "Old option `preserve-internal-and-confluent-topics` used. This option is ignored. No internal topics will be deleted."))
 

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -288,6 +288,25 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn assert-topics
+  [topics nr-of-partitions
+   & {:keys [bootstrap-server
+             confluent-api-key confluent-api-secret
+             extra-strategies]}]
+  (let [admin-client-strategies
+        (concat (keep identity
+                      [(when (and confluent-api-key confluent-api-secret)
+                         (-confluent/ConfluentCloud :api-key confluent-api-key :api-secret confluent-api-secret))])
+                extra-strategies)
+        admin-client (k/make-admin-client {:bootstrap-server bootstrap-server
+                                           :strategies       admin-client-strategies})]
+    (-kafka/assert-topics @admin-client
+                          topics
+                          {:nr-of-partitions nr-of-partitions})
+    (-comp/halt admin-client)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn list-all-topics
   [& {:keys [bootstrap-server
              confluent-api-key confluent-api-secret ;; confluent

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -25,7 +25,8 @@
            [afrolabs.components IHaltable]
            [java.util UUID]
            [afrolabs.components.kafka IPostConsumeHook IConsumerClient]
-           [clojure.lang IDeref]))
+           [clojure.lang IDeref]
+           [org.apache.kafka.clients.admin ListTopicsOptions]))
 
 (defn load-messages-from-confluent-topic
   "Loads a collection of messages from confluent kafka topics. Will stop consuming when the consumer has reached the very latest offsets.
@@ -249,22 +250,21 @@
              preserve-internal-and-confluent-topics]
       :or {extra-strategies                       []
            preserve-internal-and-confluent-topics true}}]
+  (when-not preserve-internal-and-confluent-topics
+    (log/warn "Old option `preserve-internal-and-confluent-topics` used. This option is ignored. No internal topics will be deleted."))
+
   (let [admin-client-strategies (concat (keep identity
                                               [(when (and confluent-api-key confluent-api-secret)
                                                  (-confluent/ConfluentCloud :api-key confluent-api-key :api-secret confluent-api-secret))])
                                         extra-strategies)
         admin-client (k/make-admin-client {:bootstrap-server bootstrap-server
                                            :strategies       admin-client-strategies})
-        extra-topic-predicate (if preserve-internal-and-confluent-topics
-                                (comp (filter (complement #(str/starts-with? % "_")))
-                                      (filter (complement #(str/index-of % "ksql")))
-                                      (filter (complement #(str/index-of % "connect"))))
-                                (constantly true))
+        list-topics-options (-> (ListTopicsOptions.)
+                                (.listInternal false))
         topics-to-be-deleted (into #{}
-                                   (comp (filter topic-predicate)
-                                         extra-topic-predicate)
+                                   (filter topic-predicate)
                                    (-> @admin-client
-                                       (.listTopics)
+                                       (.listTopics list-topics-options)
                                        (.names)
                                        (.get)))]
 

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -97,6 +97,10 @@
   (when value
     (edn/read-string value)))
 
+(defmethod aero/reader 'ip-hostname
+  [_ _ _value]
+  (.getHostName (java.net.InetAddress/getLocalHost)))
+
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))
 

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -59,7 +59,9 @@
   (when-not ps
     (throw (ex-info "Give the :parameters option value to the aero read-config file." {})))
   (let [result (get ps (keywordize (str value)))]
-    (when-not result (throw (ex-info (format "The parameter '%s' can not be resolved to a value." (str value)) {})))
+    (when-not result
+      (throw (ex-info (format "The parameter '%s' can not be resolved to a value." (str value))
+                      {:all-keys (keys ps)})))
     result))
 
 (defmethod aero/reader 'option
@@ -78,6 +80,12 @@
 (defmethod aero/reader 'csv-array
   [_ _ value]
   (first (csv/read-csv (java.io.StringReader. value))))
+
+(defmethod aero/reader 'long?
+  [_ _ value]
+  (when value
+    #?(:clj (Long/parseLong (str value)))
+    #?(:cljs (js/parseInt (str value)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [integrant.core :as ig]
             [taoensso.timbre :as log]
-            [clojure.data.csv :as csv]))
+            [clojure.data.csv :as csv]
+            [clojure.edn :as edn]))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -90,6 +91,11 @@
   (when (and value
              (seq value))
     (Long/parseLong (str value))))
+
+(defmethod aero/reader 'edn
+  [_ _ value]
+  (when value
+    (edn/read-string value)))
 
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -84,8 +84,10 @@
 (defmethod aero/reader 'long?
   [_ _ value]
   (when value
-    #?(:clj (Long/parseLong (str value)))
-    #?(:cljs (js/parseInt (str value)))))
+    (Long/parseLong (str value))))
+
+;; #?(:clj (Long/parseLong (str value)))
+;; #?(:cljs (js/parseInt (str value)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -87,7 +87,8 @@
 
 (defmethod aero/reader 'long?
   [_ _ value]
-  (when value
+  (when (and value
+             (seq value))
     (Long/parseLong (str value))))
 
 ;; #?(:clj (Long/parseLong (str value)))

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -77,9 +77,13 @@
 (defmethod aero/reader 'regex
   [_ _ value] (re-pattern value))
 
+(defn interpret-string-as-csv-row
+  [row-string]
+  (first (csv/read-csv (java.io.StringReader. row-string))))
+
 (defmethod aero/reader 'csv-array
   [_ _ value]
-  (first (csv/read-csv (java.io.StringReader. value))))
+  (interpret-string-as-csv-row value))
 
 (defmethod aero/reader 'long?
   [_ _ value]

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -21,14 +21,17 @@
   "timbre println appender that additionally prints out the logging context as part of the log output.
 
   based on example at https://github.com/ptaoussanis/timbre/blob/master/src/taoensso/timbre/appenders/example.clj"
-  [_appender-opts_]
-  {:enabled? true
-   :fn       (fn [data]
-               (let [{:keys [output_ context]} data
-                     output                    (force output_)]
-                 (atomic-println (str output
-                                      (when (seq context)
-                                        (str " :: [" context "]"))))))})
+  [& {:keys [colorized-output?]
+      :or   {colorized-output? false}}]
+  (cond-> {:enabled? true
+           :fn       (fn [data]
+                       (let [{:keys [output_ context]} data
+                             output                    (force output_)]
+                         (atomic-println (str output
+                                              (when (seq context)
+                                                (str " :: [" context "]"))))))}
+    (not colorized-output?)
+    (assoc :output-fn (partial timbre/default-output-fn {:stacktrace-fonts {}}))))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn configure-logging!

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -54,7 +54,7 @@
                          (when disable-stacktrace-colors
                            {:output-fn (partial timbre/default-output-fn {:stacktrace-fonts {}})})
                          (when println-context?
-                           {:appenders {println (context-println-appender {})}})))))
+                           {:appenders {:println (context-println-appender {})}})))))
 
   (timbre/merge-config! {:min-level min-level-maps}))
 

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -9,12 +9,35 @@
 (def default-min-log-level-maps [[#{"afrolabs.*"} :debug]
                                  ["*" :info]])
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; appender that prints context values to output stream
+
+(let [system-newline (System/getProperty "line.separator")]
+  (defn- atomic-println [x]
+    (print (str x system-newline))
+    (flush)))
+
+(defn context-println-appender
+  "timbre println appender that additionally prints out the logging context as part of the log output.
+
+  based on example at https://github.com/ptaoussanis/timbre/blob/master/src/taoensso/timbre/appenders/example.clj"
+  [_appender-opts_]
+  {:enabled? true
+   :fn       (fn [data]
+               (let [{:keys [output_ context]} data
+                     output                    (force output_)]
+                 (atomic-println (str output
+                                      (when (seq context)
+                                        (str " :: [" context "]"))))))})
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn configure-logging!
   [& {:keys [disable-stacktrace-colors
              min-level-maps
              min-level
              gck-logging?
              logz-io-logging?
+             println-context?
              ]
       :or {disable-stacktrace-colors false
            min-level-maps            default-min-log-level-maps
@@ -27,10 +50,14 @@
       logz-io-logging? (tas/install (assoc default-tas-config
                                            :msg-key :message))
       :else            (timbre/merge-config!
-                        (when disable-stacktrace-colors
-                          {:output-fn (partial timbre/default-output-fn {:stacktrace-fonts {}})}))))
+                        (merge
+                         (when disable-stacktrace-colors
+                           {:output-fn (partial timbre/default-output-fn {:stacktrace-fonts {}})})
+                         (when println-context?
+                           {:appenders {println (context-println-appender {})}})))))
 
   (timbre/merge-config! {:min-level min-level-maps}))
+
 
 (comment
 
@@ -46,5 +73,4 @@
   (info (Exception. "oeuoeuoeu"))
 
   )
-
 

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -56,7 +56,7 @@
                          (when println-context?
                            {:appenders {:println (context-println-appender {})}})))))
 
-  (timbre/merge-config! {:min-level min-level-maps})
+  (timbre/merge-config! {:min-level-maps min-level-maps})
   (println (str timbre/*config*)))
 
 

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -56,7 +56,8 @@
                          (when println-context?
                            {:appenders {:println (context-println-appender {})}})))))
 
-  (timbre/merge-config! {:min-level min-level-maps}))
+  (timbre/merge-config! {:min-level min-level-maps})
+  (println (str timbre/*config*)))
 
 
 (comment

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -32,7 +32,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn configure-logging!
-  [& {:keys [disable-stacktrace-colors
+  [& {:as logging-params
+      :keys [disable-stacktrace-colors
              min-level-maps
              min-level
              gck-logging?
@@ -42,7 +43,7 @@
       :or {disable-stacktrace-colors false
            min-level-maps            default-min-log-level-maps
            min-level                 :info}}]
-
+  (println (str logging-params))
   (let [default-tas-config {:level               min-level
                             :should-log-field-fn (constantly true)}]
     (cond

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -32,8 +32,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn configure-logging!
-  [& {:as logging-params
-      :keys [disable-stacktrace-colors
+  [& {:keys [disable-stacktrace-colors
              min-level-maps
              min-level
              gck-logging?
@@ -43,7 +42,6 @@
       :or {disable-stacktrace-colors false
            min-level-maps            default-min-log-level-maps
            min-level                 :info}}]
-  (println (str logging-params))
   (let [default-tas-config {:level               min-level
                             :should-log-field-fn (constantly true)}]
     (cond
@@ -57,8 +55,7 @@
                          (when println-context?
                            {:appenders {:println (context-println-appender {})}})))))
 
-  (timbre/merge-config! {:min-level min-level-maps})
-  (println (str timbre/*config*)))
+  (timbre/merge-config! {:min-level min-level-maps}))
 
 
 (comment

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -57,7 +57,7 @@
                          (when println-context?
                            {:appenders {:println (context-println-appender {})}})))))
 
-  (timbre/merge-config! {:min-level-maps min-level-maps})
+  (timbre/merge-config! {:min-level min-level-maps})
   (println (str timbre/*config*)))
 
 

--- a/src/afrolabs/prometheus.clj
+++ b/src/afrolabs/prometheus.clj
@@ -122,6 +122,6 @@
   ([registry metric-re]
    (let [^io.prometheus.client.CollectorRegistry collector-registry (promr/raw registry)
          sample-data (enumeration-seq (.metricFamilySamples collector-registry))]
-     (sequence (comp (filter #(re-matches metric-re (.name ^io.prometheus.client.SummaryMetricFamily %)))
+     (sequence (comp (filter #(re-matches metric-re (.name ^io.prometheus.client.Collector$MetricFamilySamples %)))
                      (map metric-family-samples->data))
                sample-data))))

--- a/src/afrolabs/prometheus.clj
+++ b/src/afrolabs/prometheus.clj
@@ -122,6 +122,6 @@
   ([registry metric-re]
    (let [^io.prometheus.client.CollectorRegistry collector-registry (promr/raw registry)
          sample-data (enumeration-seq (.metricFamilySamples collector-registry))]
-     (sequence (comp (filter #(re-matches metric-re (.name ^io.prometheus.client.Collector$MetricFamilySamples$Sample %)))
+     (sequence (comp (filter #(re-matches metric-re (.name ^io.prometheus.client.SummaryMetricFamily %)))
                      (map metric-family-samples->data))
                sample-data))))

--- a/src/afrolabs/prometheus.clj
+++ b/src/afrolabs/prometheus.clj
@@ -78,7 +78,7 @@
         (ring-response/response
          (ring-io/piped-input-stream
           (fn [output-stream]
-            (with-open [w (io/make-writer output-stream {})]
+            (with-open [^java.io.BufferedWriter w (io/make-writer output-stream {})]
               (iapetos.export/write-text-format! w @registry)
               (.flush w)))))))))
 
@@ -120,10 +120,8 @@
   ([metric-re] (extract-samples @registry
                                 metric-re))
   ([registry metric-re]
-   (let [sample-data (-> registry
-                         promr/raw
-                         (.metricFamilySamples)
-                         enumeration-seq)]
-     (sequence (comp (filter #(re-matches metric-re (.name %)))
+   (let [^io.prometheus.client.CollectorRegistry collector-registry (promr/raw registry)
+         sample-data (enumeration-seq (.metricFamilySamples collector-registry))]
+     (sequence (comp (filter #(re-matches metric-re (.name ^io.prometheus.client.Collector$MetricFamilySamples$Sample %)))
                      (map metric-family-samples->data))
                sample-data))))

--- a/src/afrolabs/service.clj
+++ b/src/afrolabs/service.clj
@@ -28,11 +28,11 @@
            logging-params]
     :or {config-file (*ns*-as-config-file-path)}}]
 
-  (log/info (str "Reading config file at: " config-file))
-
   (when logging-params
     (apply afrolabs.logging/configure-logging!
            logging-params))
+
+  (log/info (str "Reading config file at: " config-file))
 
   (let [dotenv-file (or dotenv-file ".env")
         ig-cfg (-config/read-config config-file
@@ -64,7 +64,6 @@
   "A service that /does logging/ is not an interactive terminal in prod and should not be writing ANSI color codes."
   [{:keys [logging-params]
     :as   cfg}]
-  (log/info (str "logging-params: " logging-params))
   (try
     (let [{health-component ::-health/component
            :as              ig-system}

--- a/src/afrolabs/service.clj
+++ b/src/afrolabs/service.clj
@@ -64,7 +64,7 @@
   "A service that /does logging/ is not an interactive terminal in prod and should not be writing ANSI color codes."
   [{:keys [logging-params]
     :as   cfg}]
-
+  (log/info (str "logging-params: " logging-params))
   (try
     (let [{health-component ::-health/component
            :as              ig-system}

--- a/src/afrolabs/service.clj
+++ b/src/afrolabs/service.clj
@@ -61,15 +61,21 @@
         nil))))
 
 (defn as-service
-  "A service that /does logging/ is not an interactive terminal in prod and should not be writing ANSI color codes."
+  "A service that /does logging/ is not an interactive terminal in prod and should not be writing ANSI color codes.
+  - `logging-params` may have several values:
+    - `nil` - default logging setup will be performed
+    - sequence of parameters that will be passed to `as-system`. Read the code there to understand what it will do.
+    - `:component` - Used when there is a seperate logging integrant component. This is a backward-compatibility flag.
+  "
   [{:keys [logging-params]
     :as   cfg}]
   (try
     (let [{health-component ::-health/component
            :as              ig-system}
-          (as-system (assoc cfg
-                            :logging-params (into [:disable-stacktrace-colors true]
-                                                  logging-params)))]
+          (as-system (cond-> cfg
+                       (not= :component logging-params)
+                       (assoc :logging-params (into [:disable-stacktrace-colors true]
+                                                    logging-params))))]
 
       (log/info "System started...")
       (-health/wait-while-healthy health-component)

--- a/src/afrolabs/service.clj
+++ b/src/afrolabs/service.clj
@@ -5,7 +5,9 @@
             [integrant.core :as ig]
             [afrolabs.components.health :as -health]
             [clojure.pprint :as pprint]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [afrolabs.spec :as -spec]))
 
 
 (defn *ns*-as-config-file-path
@@ -17,6 +19,12 @@
             (str/join "/" ))
        "/config.edn"))
 
+(s/def ::log-component-kw keyword?)
+(s/def ::log-component-dependencies-pred ifn?)
+
+(s/def ::log-component-setup
+  (s/keys :req-un [::log-component-kw
+                   ::log-component-dependencies-pred]))
 
 ;; TODO - require a bloody spec for the arguments
 (defn as-system
@@ -25,20 +33,39 @@
            dotenv-file
            profile
            ig-cfg-ks
-           logging-params]
+           logging-params
+           log-component-setup]
     :or {config-file (*ns*-as-config-file-path)}}]
 
   (when logging-params
     (apply afrolabs.logging/configure-logging!
            logging-params))
 
+  (when log-component-setup
+    (-spec/assert! ::log-component-setup log-component-setup))
+
   (log/info (str "Reading config file at: " config-file))
 
   (let [dotenv-file (or dotenv-file ".env")
-        ig-cfg (-config/read-config config-file
-                                    :dotenv-file dotenv-file
-                                    :profile (or profile :prod)
-                                    :cli-args cli-args)
+        ig-cfg' (-config/read-config config-file
+                                     :dotenv-file dotenv-file
+                                     :profile (or profile :prod)
+                                     :cli-args cli-args)
+        ;; when log-component-setup is defined, we will dynamically modify the aero config.
+        ;; We will make all components depend ON the logging component (log-component-kw)
+        ;; EXCEPT the ones that satisfies log-component-dependencies-pred
+        ig-cfg (if-not log-component-setup
+                 ig-cfg'
+                 (into {}
+                       (map (fn [[component-kw component-cfg]]
+                              [component-kw
+                               (if (and (not ((:log-component-dependencies-pred log-component-setup) component-kw))
+                                        (not= (:log-component-kw log-component-setup)
+                                              component-kw))
+                                 (assoc component-cfg
+                                        ::fake-logging-dependency (ig/ref (:log-component-kw log-component-setup)))
+                                 component-cfg)]))
+                       ig-cfg'))
 
         ig-cfg-ks (or ig-cfg-ks (keys ig-cfg)) ;; default is everything
 


### PR DESCRIPTION
The changes in this MR supports the work done for load-testing in gometro/bridge-telemetry.

## Summary

- updated dependencies including amongst others:
  - confluent/kafka
  - `com.clojure-goes-fast/clj-async-profiler` (flamegraphs)
  - `com.cnuernber/charred` (faster JSON)
- added type hints in a few places to save on reflection
- kafka related
  - counters for messages consumed and messages produced
  - `CaughtUpOnceNotifications` strategy. This is usedful for letting ktables finish loading once they've reached the end-offsets at the time of starting up, so they don't get stuck infinitely loading newer and newer data, without letting the rest of the system starting up.
  - Using charred JSON parsing library in deserializers/serializers
  - fine-tuning kafka utilities for deleting topics to prevent deleting internal and confluent topics
 
 

