### PR TITLE
Maintenance

### DIFF
--- a/src/afrolabs/components/http.clj
+++ b/src/afrolabs/components/http.clj
@@ -69,12 +69,18 @@
   [handler {:as logging-context
             :keys [port ip]}]
   (fn [{:as req
-        :keys [uri]}]
-    (let [{:as   res
-           :keys [status]} (log/with-context+ logging-context
-                             (handler req))]
-      (log/debug (str ip ":" port uri " [" status "]"))
-      res)))
+        :keys [uri
+               remote-addr
+               request-method]}]
+    (log/with-context+ logging-context
+      (let [{:as   res
+             :keys [status]} (handler req)]
+        (log/with-context+ {:status         status
+                            :uri            uri
+                            :remote-addr    remote-addr
+                            :request-method request-method}
+          (log/info (str ip ":" port uri " [" status "]")))
+        res))))
 
 (defn create-http-component
   [{:keys [port

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -584,7 +584,8 @@
                      (t/instant)
                      (t/to-millis-from-epoch))
 
-                 (= java.time.Instant (type offset))
+                 (#{java.time.Instant
+                    java.time.ZonedDateTime} (type offset))
                  (t/to-millis-from-epoch offset))]
     (reify
       IConsumerPostInitHook

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1532,9 +1532,11 @@
                                             (str t) (str k) (str v)))
                               old)))
                         (fn [old-meta]
-                          (update-in old-meta [:ktable/partition-offsets p]
-                                     (fnil #(max % o)
-                                           -1))))
+                          (if-not (and o p)
+                            old-meta
+                            (update-in old-meta [:ktable/partition-offsets p]
+                                       (fnil #(max % o)
+                                             -1)))))
              rest-msgs))))
 
 (s/def ::ktable-id (s/and string?


### PR DESCRIPTION
- Some fixes to strategies seeking to specific offsets. This is useful during dev when loading data to manually inspect it and limits the amount of data returned.
- HTTP request logging has been improved
- disable the automatic calculation of consumer lag for every consumer
- add partition-offset meta-data to the ktable value. This will position gometro for a `consistency-token` mechanism on the API to help gaurd against race conditions.