### PR TITLE
Maintenance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/Afrolabs/afrolabs-clj</url>
     <connection>scm:git:git://github.com/Afrolabs/afrolabs-clj.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Afrolabs/afrolabs-clj.git</developerConnection>
-    <tag>aa289f95a0778ca6993af9104c7692b3a22a5fb3</tag>
+    <tag>83b4c84fbd7d17d03ea6d6e39756fceb279bfef1</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -290,6 +290,11 @@
       <groupId>nrepl</groupId>
       <artifactId>nrepl</artifactId>
       <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.taoensso</groupId>
+      <artifactId>encore</artifactId>
+      <version>3.114.0</version>
     </dependency>
     <dependency>
       <groupId>com.taoensso</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/Afrolabs/afrolabs-clj</url>
     <connection>scm:git:git://github.com/Afrolabs/afrolabs-clj.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Afrolabs/afrolabs-clj.git</developerConnection>
-    <tag>422518831d3fe1807e391c7e4f52aa036b1c0ab2</tag>
+    <tag>aa289f95a0778ca6993af9104c7692b3a22a5fb3</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -75,6 +75,11 @@
   <dependencies>
     <dependency>
       <groupId>org.clojure</groupId>
+      <artifactId>spec.alpha</artifactId>
+      <version>0.5.238</version>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
       <version>1.11.3</version>
     </dependency>
@@ -87,6 +92,12 @@
       <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
       <version>1.11.132</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>transit-java</artifactId>
+          <groupId>com.cognitect</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -101,17 +112,17 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
-      <version>9.4.54.v20240208</version>
+      <version>9.4.55.v20240627</version>
     </dependency>
     <dependency>
       <groupId>camel-snake-kebab</groupId>
@@ -121,7 +132,7 @@
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>jsonista</artifactId>
-      <version>0.3.8</version>
+      <version>0.3.9</version>
       <exclusions>
         <exclusion>
           <artifactId>jackson-core</artifactId>
@@ -171,6 +182,11 @@
     </dependency>
     <dependency>
       <groupId>buddy</groupId>
+      <artifactId>buddy-core</artifactId>
+      <version>1.12.0-430</version>
+    </dependency>
+    <dependency>
+      <groupId>buddy</groupId>
       <artifactId>buddy-hashers</artifactId>
       <version>2.0.167</version>
     </dependency>
@@ -182,22 +198,22 @@
     <dependency>
       <groupId>buddy</groupId>
       <artifactId>buddy-sign</artifactId>
-      <version>3.5.351</version>
+      <version>3.6.1-359</version>
     </dependency>
     <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-core</artifactId>
-      <version>1.12.1</version>
+      <version>1.12.2</version>
     </dependency>
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>ring-http-response</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
     </dependency>
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>reitit</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.1</version>
       <exclusions>
         <exclusion>
           <artifactId>jackson-core</artifactId>
@@ -216,6 +232,11 @@
       <version>1.8.0</version>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.4.0-b180830.0359</version>
+    </dependency>
+    <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
       <version>0.16.0</version>
@@ -228,7 +249,7 @@
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>iapetos</artifactId>
-      <version>0.1.13</version>
+      <version>0.1.14</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
@@ -238,7 +259,7 @@
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>endpoints</artifactId>
-      <version>1.1.12.682</version>
+      <version>1.1.12.718</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
@@ -248,7 +269,7 @@
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>sqs</artifactId>
-      <version>857.2.1574.0</version>
+      <version>869.2.1616.0</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
@@ -258,7 +279,7 @@
     <dependency>
       <groupId>com.cognitect.aws</groupId>
       <artifactId>monitoring</artifactId>
-      <version>857.2.1574.0</version>
+      <version>868.2.1599.0</version>
     </dependency>
     <dependency>
       <groupId>com.cognitect.aws</groupId>
@@ -268,7 +289,7 @@
     <dependency>
       <groupId>nrepl</groupId>
       <artifactId>nrepl</artifactId>
-      <version>1.1.1</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.taoensso</groupId>
@@ -303,22 +324,22 @@
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>malli</artifactId>
-      <version>0.16.1</version>
+      <version>0.16.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>com.fzakaria</groupId>
@@ -328,17 +349,17 @@
     <dependency>
       <groupId>viesti</groupId>
       <artifactId>timbre-json-appender</artifactId>
-      <version>0.2.13</version>
+      <version>0.2.14</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.17.0</version>
+      <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.re2j</groupId>
@@ -348,7 +369,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.77</version>
+      <version>1.78.1</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.reload4j</groupId>
@@ -387,7 +408,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.12</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>io.confluent</groupId>
@@ -397,7 +418,7 @@
     <dependency>
       <groupId>thheller</groupId>
       <artifactId>shadow-cljs</artifactId>
-      <version>2.28.8</version>
+      <version>2.28.11</version>
     </dependency>
     <dependency>
       <groupId>gsnewmark</groupId>
@@ -415,6 +436,11 @@
       <version>1.2.2</version>
     </dependency>
     <dependency>
+      <groupId>com.clojure-goes-fast</groupId>
+      <artifactId>clj-memory-meter</artifactId>
+      <version>0.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>lambdaisland</groupId>
       <artifactId>uri</artifactId>
       <version>1.19.155</version>
@@ -430,9 +456,14 @@
       <version>1.5.0</version>
     </dependency>
     <dependency>
+      <groupId>com.cognitect</groupId>
+      <artifactId>transit-clj</artifactId>
+      <version>1.0.333</version>
+    </dependency>
+    <dependency>
       <groupId>com.clojure-goes-fast</groupId>
       <artifactId>clj-java-decompiler</artifactId>
-      <version>0.3.4</version>
+      <version>0.3.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,10 @@
   :repositories [["confluent" "https://packages.confluent.io/maven/"]]
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :sign-releases false}]]
-  :dependencies [[org.clojure/clojure "1.11.3"]
+  :dependencies [[org.clojure/spec.alpha "0.5.238"]
+                 [org.clojure/clojure "1.11.3"]
                  [com.google.javascript/closure-compiler-unshaded "v20240317"]
-                 [org.clojure/clojurescript "1.11.132"]
+                 [org.clojure/clojurescript "1.11.132" :exclusions [com.cognitect/transit-java]]
 
                  ;; property-based testing, generative testing
                  [org.clojure/test.check "1.1.1"]
@@ -22,16 +23,16 @@
                  ;; I'm not sure why we're choosing an old version of jetty here.
                  ;; might be cognitect.
                  ;; https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-util
-                 [org.eclipse.jetty/jetty-util "9.4.54.v20240208"]
-                 [org.eclipse.jetty/jetty-http "9.4.54.v20240208"]
-                 [org.eclipse.jetty/jetty-client "9.4.54.v20240208"]
+                 [org.eclipse.jetty/jetty-util "9.4.55.v20240627"]
+                 [org.eclipse.jetty/jetty-http "9.4.55.v20240627"]
+                 [org.eclipse.jetty/jetty-client "9.4.55.v20240627"]
 
                  ;; conversions between different kinds of casing
                  ;; camelCase -> snake_case -> kebab-case -> PascalCase
                  [camel-snake-kebab "0.4.3"]
 
 
-                 [metosin/jsonista "0.3.8" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [metosin/jsonista "0.3.9" :exclusions [com.fasterxml.jackson.core/jackson-core]]
 
                  ;; monadic utilities for validation, failure and error checking
                  ;; https://github.com/adambard/failjure
@@ -63,40 +64,44 @@
                  [http-kit "2.8.0"]
 
                  ;; password-hashing helpers
+                 [buddy/buddy-core "1.12.0-430"]
                  [buddy/buddy-hashers "2.0.167"]
                  [buddy/buddy-auth "3.0.323"]
-                 [buddy/buddy-sign "3.5.351"]
+                 [buddy/buddy-sign "3.6.1-359"]
 
-                 [ring/ring-core "1.12.1"]
+                 [ring/ring-core "1.12.2"]
 
                  ;; https://github.com/metosin/ring-http-response
                  ;; ring response helper fns
-                 [metosin/ring-http-response "0.9.3"]
+                 [metosin/ring-http-response "0.9.4"]
 
                  ;; http routing library
                  ;; https://github.com/metosin/reitit
-                 [metosin/reitit "0.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [metosin/reitit "0.7.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
 
                  ;; https://github.com/dm3/clojure.java-time
                  [clojure.java-time "1.4.2"]
                  [org.threeten/threeten-extra "1.8.0"]
 
+                 ;; jaxb, common between iapetos & transit
+                 [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
+
                  ;; https://github.com/clj-commons/iapetos
                  [io.prometheus/simpleclient "0.16.0"]
                  [io.prometheus/simpleclient_hotspot "0.16.0"]
-                 [clj-commons/iapetos "0.1.13"]
+                 [clj-commons/iapetos "0.1.14"]
 
                  ;; cognitect (custodians of clojure) has a very nice data driven API interface to AWS
                  [com.cognitect.aws/api "0.8.692"]
-                 [com.cognitect.aws/endpoints "1.1.12.682"]
+                 [com.cognitect.aws/endpoints "1.1.12.718"]
                  [com.cognitect.aws/sns "857.2.1574.0"]
-                 [com.cognitect.aws/sqs "857.2.1574.0"]
+                 [com.cognitect.aws/sqs "869.2.1616.0"]
                  [com.cognitect.aws/s3 "868.2.1580.0"]
-                 [com.cognitect.aws/monitoring "857.2.1574.0"]
+                 [com.cognitect.aws/monitoring "868.2.1599.0"]
                  [com.cognitect.aws/logs "868.2.1584.0"]
 
                  ;; NREPL
-                 [nrepl "1.1.1"]
+                 [nrepl "1.2.0"]
 
                  ;; logging for clj(s) https://github.com/ptaoussanis/timbre
                  [com.taoensso/timbre "6.5.0"]
@@ -113,12 +118,12 @@
                  [fipp "0.6.26"]
 
                  ;; malli; schema-driven development and utilities
-                 [metosin/malli "0.16.1"]
+                 [metosin/malli "0.16.2"]
 
                  ;; hooking in the result of other java logging frameworks into slf4j
-                 [org.slf4j/log4j-over-slf4j "2.0.12"]
-                 [org.slf4j/jul-to-slf4j "2.0.12"]
-                 [org.slf4j/jcl-over-slf4j "2.0.12"]
+                 [org.slf4j/log4j-over-slf4j "2.0.13"]
+                 [org.slf4j/jul-to-slf4j "2.0.13"]
+                 [org.slf4j/jcl-over-slf4j "2.0.13"]
 
                  ;; then routing slf4j to timbre
                  ;; This will allow us to receive, log (and configure) the logs provided by libraries
@@ -126,10 +131,10 @@
                  [com.fzakaria/slf4j-timbre "0.4.1"]
 
                  ;; possibility to log to json, for use in cloud environments like GCK
-                 [viesti/timbre-json-appender "0.2.13"]
+                 [viesti/timbre-json-appender "0.2.14"]
 
-                 [com.fasterxml.jackson.core/jackson-databind "2.17.0"]
-                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.17.0"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.17.2"]
+                 [com.fasterxml.jackson.datatype/jackson-datatype-jsr310 "2.17.2"]
 
 
                  ;; https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
@@ -143,7 +148,7 @@
                  ;; dependency conflict resolution introduced by confluent libraries
                  ;; [com.fasterxml.jackson.datatype/jackson-datatype-jdk8 "2.16.1"]
                  [com.google.re2j/re2j "1.7"]
-                 [org.bouncycastle/bcpkix-jdk18on "1.77"]
+                 [org.bouncycastle/bcpkix-jdk18on "1.78.1"]
                  [ch.qos.reload4j/reload4j "1.2.25"]
                  [org.javassist/javassist "3.29.0-GA"]
 
@@ -158,16 +163,17 @@
                  ;;                                                                 org.glassfish.jersey.core/jersey-common]]
 
                  ;; for use with ksqld, the java client
+                 ;; I've tried updating this to 7.6.1, but some dependencies could not resolve... (Thu Aug  1 03:43:59 PM SAST 2024)
                  [io.confluent.ksql/ksqldb-api-client "7.6.0" :exclusions [org.slf4j/slf4j-log4j12
                                                                            org.bouncycastle/bc-fips
                                                                            org.javassist/javassist]]
 
-                 [org.slf4j/slf4j-api "2.0.12"]
+                 [org.slf4j/slf4j-api "2.0.13"]
                  ;; [org.slf4j/slf4j-log4j12 "1.7.32"]
                  [io.confluent/confluent-log4j "1.2.17-cp5"]
 
                  
-                 [thheller/shadow-cljs "2.28.8"]
+                 [thheller/shadow-cljs "2.28.11"]
 
                  ;; middleware that adds "X-Clacks-Overhead" to responses
                  [gsnewmark/ring-pratchett "0.1.0"]
@@ -189,10 +195,13 @@
                  ;; parsing strings
                  [instaparse "1.5.0"]
 
+                 ;; transit
+                 [com.cognitect/transit-clj "1.0.333"]
+
                  ]
   :aot [afrolabs.components.kafka.json-serdes
         afrolabs.components.kafka.edn-serdes
         afrolabs.components.kafka.bytes-serdes
         afrolabs.components.confluent.schema-registry-compatible-serdes]
   :repl-options {}
-  :profiles {:dev {:dependencies [[com.clojure-goes-fast/clj-java-decompiler "0.3.4"]]}})
+  :profiles {:dev {:dependencies [[com.clojure-goes-fast/clj-java-decompiler "0.3.6"]]}})

--- a/project.clj
+++ b/project.clj
@@ -202,6 +202,7 @@
   :aot [afrolabs.components.kafka.json-serdes
         afrolabs.components.kafka.edn-serdes
         afrolabs.components.kafka.bytes-serdes
+        afrolabs.components.kafka.transit-serdes
         afrolabs.components.confluent.schema-registry-compatible-serdes]
   :repl-options {}
   :profiles {:dev {:dependencies [[com.clojure-goes-fast/clj-java-decompiler "0.3.6"]]}})

--- a/project.clj
+++ b/project.clj
@@ -178,6 +178,7 @@
                  ;; profiling
                  ;; this is safe to distribute into prod according to the docs
                  [com.clojure-goes-fast/clj-async-profiler "1.2.2"]
+                 [com.clojure-goes-fast/clj-memory-meter "0.3.0"]
 
                  ;; uri handling
                  [lambdaisland/uri "1.19.155"]

--- a/project.clj
+++ b/project.clj
@@ -104,6 +104,7 @@
                  [nrepl "1.2.0"]
 
                  ;; logging for clj(s) https://github.com/ptaoussanis/timbre
+                 [com.taoensso/encore "3.114.0"]
                  [com.taoensso/timbre "6.5.0"]
 
                  ;; https://github.com/clojure/data.json

--- a/src/afrolabs/components.clj
+++ b/src/afrolabs/components.clj
@@ -49,3 +49,8 @@
        (defmacro ~redeclaration-macro-name [kw#]
          `(-write-integrant-multis ~kw# ~~init-fn-name)))))
 
+
+(s/def ::identity-component-cfg any?)
+(defcomponent {::ig-kw       ::identity-component
+               ::config-spec ::identity-component-cfg}
+  [self] self)

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1378,23 +1378,20 @@
                                                                    (.allTopicNames)
                                                                    (.get))
 
-                                               topics-with-too-few-partitions
-                                               (into {}
-                                                     (for [topic existing-topics-to-check
-                                                           :let [^TopicDescription topic-describe-result
-                                                                 (get describe-result topic)
+                                               topics-createPartitions-parameter
+                                               (->> (for [topic existing-topics-to-check
+                                                          :let [^TopicDescription topic-describe-result
+                                                                (get describe-result topic)
 
-                                                                 max-partition
-                                                                 (apply max (map #(.partition ^TopicPartitionInfo %)
-                                                                                 (.partitions topic-describe-result)))]
-                                                           :when (< max-partition (dec nr-of-partitions))]
-                                                       [topic (NewPartitions/increaseTo nr-of-partitions)]))
-
-                                               topic-mod-result
-                                               (when (seq topics-with-too-few-partitions)
-                                                 (.createPartitions admin-client
-                                                                    topics-with-too-few-partitions))]
-                                           topic-mod-result))]
+                                                                max-partition
+                                                                (apply max (map #(.partition ^TopicPartitionInfo %)
+                                                                                (.partitions topic-describe-result)))]
+                                                          :when (< max-partition (dec nr-of-partitions))]
+                                                      [topic (NewPartitions/increaseTo nr-of-partitions)])
+                                                    (into {}))]
+                                           (when (seq topics-with-too-few-partitions)
+                                             (.createPartitions admin-client
+                                                                topics-createPartitions-parameter))))]
 
     ;; wait for complete success
     (-> topic-create-result

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -15,10 +15,10 @@
    [iapetos.core :as prom]
    [integrant.core :as ig]
    [java-time :as t]
+   [net.cgrand.xforms :as x]
    [taoensso.timbre :as log]
    [taoensso.timbre :as timbre :refer [log  trace  debug  info  warn  error  fatal  report logf tracef debugf infof warnf errorf fatalf reportf spy get-env]]
-
-   [net.cgrand.xforms :as x])
+   )
   (:import [org.apache.kafka.clients.producer ProducerConfig ProducerRecord KafkaProducer Producer Callback RecordMetadata]
            [org.apache.kafka.clients.consumer ConsumerConfig KafkaConsumer MockConsumer OffsetResetStrategy ConsumerRecord Consumer ConsumerRebalanceListener OffsetAndTimestamp]
            [org.apache.kafka.clients.admin AdminClient AdminClientConfig NewTopic DescribeConfigsResult Config AlterConfigOp AlterConfigOp$OpType ConfigEntry]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1471,8 +1471,12 @@
                                                           #(< 0.0 % 1.0))))
 (s/def ::recreate-topics-with-bad-config boolean?)
 (s/def ::update-topics-with-bad-config boolean?)
-(s/def ::ktable-compaction-policy #{"compact"
+(s/def ::ktable-compaction-policy #{;; normal compaction, keeps the last value of records by key
+                                    "compact"
+                                    ;; keeps the last value of a record by key, for the retention period
+                                    ;; If no updates are received, the record is deleted
                                     "delete,compact"
+                                    ;; same as `delete,compact`
                                     "compact,delete"})
 (s/def ::ktable-asserter-cfg (s/and ::admin-client-cfg
                                     (s/keys :req-un [::topic-name-providers]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -19,16 +19,37 @@
    [taoensso.timbre :as log]
    [taoensso.timbre :as timbre :refer [log  trace  debug  info  warn  error  fatal  report logf tracef debugf infof warnf errorf fatalf reportf spy get-env]]
    )
-  (:import [org.apache.kafka.clients.producer ProducerConfig ProducerRecord KafkaProducer Producer Callback RecordMetadata]
-           [org.apache.kafka.clients.consumer ConsumerConfig KafkaConsumer MockConsumer OffsetResetStrategy ConsumerRecord Consumer ConsumerRebalanceListener OffsetAndTimestamp]
-           [org.apache.kafka.clients.admin AdminClient AdminClientConfig NewTopic DescribeConfigsResult Config AlterConfigOp AlterConfigOp$OpType ConfigEntry]
-           [org.apache.kafka.common.header Header Headers]
-           [org.apache.kafka.common.config ConfigResource ConfigResource$Type ]
-           [org.apache.kafka.common TopicPartition]
-           [java.util.concurrent Future]
-           [java.util Map Collection UUID Optional]
-           [afrolabs.components IHaltable]
-           [clojure.lang IDeref IRef IBlockingDeref]))
+  (:import [org.apache.kafka.clients.producer
+            ProducerConfig ProducerRecord KafkaProducer Producer Callback RecordMetadata]
+
+           [org.apache.kafka.clients.consumer
+            ConsumerConfig KafkaConsumer MockConsumer OffsetResetStrategy ConsumerRecord Consumer
+            ConsumerRebalanceListener OffsetAndTimestamp]
+
+           [org.apache.kafka.clients.admin
+            AdminClient AdminClientConfig NewTopic DescribeConfigsResult Config AlterConfigOp
+            AlterConfigOp$OpType ConfigEntry TopicDescription NewPartitions]
+
+           [org.apache.kafka.common.header
+            Header Headers]
+
+           [org.apache.kafka.common.config
+            ConfigResource ConfigResource$Type]
+
+           [org.apache.kafka.common
+            TopicPartition TopicPartitionInfo]
+
+           [java.util.concurrent
+            Future]
+
+           [java.util
+            Map Collection UUID Optional]
+
+           [afrolabs.components
+            IHaltable]
+
+           [clojure.lang
+            IDeref IRef IBlockingDeref]))
 
 
 (comment
@@ -1360,12 +1381,14 @@
                                                topics-with-too-few-partitions
                                                (into {}
                                                      (for [topic existing-topics-to-check
-                                                           :let [^org.apache.kafka.clients.admin.TopicDescription
-                                                                 topic-describe-result (get describe-result topic)
-                                                                 max-partition (apply max (map #(.partition ^org.apache.kafka.common.TopicPartitionInfo %)
-                                                                                               (.partitions topic-describe-result)))]
+                                                           :let [^TopicDescription topic-describe-result
+                                                                 (get describe-result topic)
+
+                                                                 max-partition
+                                                                 (apply max (map #(.partition ^TopicPartitionInfo %)
+                                                                                 (.partitions topic-describe-result)))]
                                                            :when (< max-partition (dec nr-of-partitions))]
-                                                       [topic (org.apache.kafka.clients.admin.NewPartitions/increaseTo nr-of-partitions)]))
+                                                       [topic (NewPartitions/increaseTo nr-of-partitions)]))
 
                                                topic-mod-result
                                                (when (seq topics-with-too-few-partitions)

--- a/src/afrolabs/components/kafka/transit_serdes.clj
+++ b/src/afrolabs/components/kafka/transit_serdes.clj
@@ -1,0 +1,90 @@
+(ns afrolabs.components.kafka.transit-serdes
+  (:gen-class
+   :implements [org.apache.kafka.common.serialization.Serializer]
+   :main false)
+  (:require [clojure.tools.reader.edn :as edn]
+            [taoensso.timbre :as log]
+            [java-time :as t]
+            [afrolabs.transit :as -transit])
+  (:import
+   [java.io ByteArrayOutputStream ByteArrayInputStream]
+   [org.apache.kafka.common.header Headers]
+   [java.nio ByteBuffer]))
+
+(comment
+
+  (set! *warn-on-reflection* true)
+
+  )
+
+(gen-class :name "afrolabs.components.kafka.transit_serdes.Serializer"
+           :prefix "ser-"
+           :main false
+           :implements [org.apache.kafka.common.serialization.Serializer])
+
+(defn ser-serialize
+  ([_ _ data]
+   (when data
+     (-transit/write-transit-bytes data)))
+  ([this _ _ data]
+   (ser-serialize this nil data)))
+
+(defn ser-close [_])
+(defn ser-configure [_ _ _])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(gen-class :name "afrolabs.components.kafka.transit_serdes.Deserializer"
+           :prefix "deser-"
+           :state state
+           :init init
+           :main false
+           :implements [org.apache.kafka.common.serialization.Deserializer])
+
+(defn deser-init []
+  [[] (atom nil)])
+
+(defn deser-deserialize-String-Headers-byte<>
+  ([_this topic ^bytes byte-data]
+   (when byte-data
+     (try (-transit/read-transit (ByteArrayInputStream. byte-data))
+          (catch Throwable t
+            (log/error t (str "Unable to deserialize transit from topic '" topic "'.\n"
+                              "The string value of the data is: \n" (String. ^bytes byte-data) "\n"
+                              "The byte-array value is: " (mapv identity byte-data)))))))
+  ([this _ _ byte-data]
+   (deser-deserialize-String-Headers-byte<> this nil byte-data)))
+
+(defn deser-deserialize-String-Headers-ByteBuffer
+  ([_this topic ^ByteBuffer byte-data]
+   (when byte-data
+     (let [byte-array (make-array Byte/TYPE (.remaining byte-data))]
+       (.get byte-data ^bytes byte-array)
+       (try (-transit/read-transit (ByteArrayInputStream. byte-array))
+            (catch Throwable t
+              (log/error t (str "Unable to deserialize transit from topic '" topic "'.\n"
+                                "The string value of the data is: \n" (String. ^bytes byte-array) "\n"
+                                "The byte-array value is: " (mapv identity byte-array))))))))
+  ([this _ _ byte-data]
+   (deser-deserialize-String-Headers-ByteBuffer this nil byte-data)))
+
+(defn deser-close [_])
+(defn deser-configure [_this _config-settings _])
+
+(comment
+
+  (compile 'afrolabs.components.kafka.transit-serdes)
+
+
+  (def ser (afrolabs.components.kafka.transit_serdes.Serializer.))
+
+  (def bs (.serialize ser "topic" {:a 1}))
+
+  (def des (afrolabs.components.kafka.transit_serdes.Deserializer.))
+
+  (.deserialize ^org.apache.kafka.common.serialization.Deserializer des
+                "oeu"
+                (byte-array bs))
+
+
+  )

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -151,8 +151,7 @@
       ;; return value
       (when collect-messages?
         (let [all-msgs (persistent! @loaded-msgs)]
-          (or (when (and nr-msgs
-                         (number? nr-msgs))
+          (or (when (number? nr-msgs)
                 (into []
                       (comp (mapcat identity)
                             (take nr-msgs))

--- a/src/afrolabs/transit.clj
+++ b/src/afrolabs/transit.clj
@@ -1,0 +1,105 @@
+(ns afrolabs.transit
+  (:require [cognitect.transit :as t])
+  (:import [java.io ByteArrayOutputStream ByteArrayInputStream]
+           [java.time
+            Period
+            LocalDate
+            LocalDateTime
+            ZonedDateTime
+            OffsetTime
+            Instant
+            OffsetDateTime
+            ZoneId
+            DayOfWeek
+            LocalTime
+            Month
+            Duration
+            Year
+            YearMonth]))
+
+(def ^:private time-classes
+  {'period           {:class    Period
+                      :read-fn  #(Period/parse %)}
+   'date             {:class   LocalDate
+                      :read-fn #(LocalDate/parse %)}
+   'date-time        {:class   LocalDateTime
+                      :read-fn #(LocalDateTime/parse %)}
+   'zoned-date-time  {:class   ZonedDateTime
+                      :read-fn #(ZonedDateTime/parse %)}
+   'offset-time      {:class   OffsetTime
+                      :read-fn #(OffsetTime/parse %)}
+   'instant          {:class   Instant
+                      :read-fn #(Instant/parse %)}
+   'offset-date-time {:class   OffsetDateTime
+                      :read-fn #(OffsetDateTime/parse %)}
+   'time             {:class   LocalTime
+                      :read-fn #(LocalTime/parse %)}
+   'duration         {:class   Duration
+                      :read-fn #(Duration/parse %)}
+   'year             {:class   Year
+                      :read-fn #(Year/parse %)}
+   'year-month       {:class   YearMonth
+                      :read-fn #(YearMonth/parse %)}
+   'zone             {:class   ZoneId
+                      :read-fn #(ZoneId/of %)}
+   'day-of-week      {:class   DayOfWeek
+                      :write-fn #(.getValue ^DayOfWeek %)
+                      :read-fn #(DayOfWeek/of (int %))}
+   'month            {:class   Month
+                      :write-fn #(.getValue ^Month %)
+                      :read-fn #(Month/of (int %))}})
+
+(def ^:private write-handlers
+  (into {}
+        (for [[time-name {time-class :class
+                          :keys      [write-fn]
+                          :or        {write-fn str}}]        time-classes]
+          [time-class (t/write-handler (str "time/" time-name) write-fn)])))
+
+(def ^:private read-handlers
+  (into {}
+        (for [[time-name {:keys [read-fn]}] time-classes]
+          [(str "time/" time-name) (t/read-handler read-fn)])))
+
+(defn write-transit [coll output-stream]
+  (t/write (t/writer output-stream
+                     :json
+                     {:handlers write-handlers})
+           coll))
+
+(defn write-transit-bytes ^bytes [o]
+  (let [os (ByteArrayOutputStream.)]
+    (write-transit o os)
+    (.toByteArray os)))
+
+(defn write-transit-json ^String [o]
+  (String. (write-transit-bytes o) "UTF-8"))
+
+(defn read-transit [input-stream]
+  (t/read (t/reader input-stream
+                    :json
+                    {:handlers read-handlers})))
+
+(defn read-transit-json [^String s]
+  (read-transit (ByteArrayInputStream. (.getBytes s "UTF-8"))))
+
+(comment
+
+  (let [data [(Period/ofDays 8)
+              (LocalDate/now)
+              (LocalDateTime/now)
+              (ZonedDateTime/now)
+              (Instant/now)
+              (OffsetDateTime/now)
+              (LocalTime/now)
+              (Duration/ofHours 6)
+              (Year/now)
+              (YearMonth/now)
+              (ZoneId/systemDefault)
+              (DayOfWeek/SUNDAY)
+              (Month/MAY)]
+        written (write-transit-bytes data)
+        read (read-transit (ByteArrayInputStream. written))]
+    (assert (= data read)))
+
+  )


### PR DESCRIPTION
- added dependencies:
  - transit
  - clojure-goes-fast/memory-meter
- straightened out dependency conflicts
- create the `identity-component`, which allows a straight map containing config values to be a component
- for AWS' `make-aws-client` components, create `load-ss?` parameter to configure if SSO credentials should be part of the list of credential-providers (cognitect aws library)
- added kafka transit-serdes class
- Allow kafka-utilities/load-messages-from-topic to stream loaded messages to core.async channel (and optionally not keeping the complete list of loaded messages in-memory)
- topic-asserter: partitions may now _grow_ to match the configured number
- ktable-asserter: may now dynamically change the `cleanup.policy` of an existing topic, rather than trying to delete it in order to recreate it.