### PR TITLE
Maintenance

### DIFF
--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -2030,13 +2030,13 @@
              ;; We need the path [topic record-key] to the records we will expunge
              ;; so we can expunge table-level meta-data too
              topic-partition-keys (map (juxt first second)
-                                       (specter/select [specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect topic name, continue to topic value-map
+                                       (specter/select [:ktable/record-data
+                                                        specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect topic name, continue to topic value-map
                                                         specter/ALL (specter/collect-one specter/FIRST) specter/LAST ;; collect record key, continue to record value
-                                                        specter/META                                                 ;; navigate into the record's meta-data
                                                         :timestamp                                                   ;; navigate to :timestamp
                                                         #(t/before? % cutoff-timestamp)                              ;; match only when :timestamp is before cutoff
                                                         ]
-                                                       result))
+                                                       (meta result)))
              result-without-records (reduce (fn [acc [topic record-key]]
                                               (update acc topic dissoc record-key))
                                             result

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -358,24 +358,21 @@
   `the-fn` might be a symbol, in which case the namespace will be recquired and the symbol resolved
   or an actual `IFn`."
   [the-fn]
-  (or (when the-fn
-        (cond
-          (fn? the-fn)       the-fn
-          (symbol? the-fn)   (let [the-fn-ref (var-get (requiring-resolve the-fn))]
-                                 (if-not (fn? the-fn-ref)
-                                   (throw (ex-info "`the-fn` must be an fn or a symbol that points to an fn."
-                                                   {:the-fn the-fn}))
-                                   the-fn-ref))
-          :else
-          (do (log/with-context+ {:the-fn the-fn}
-                (log/warn "Unable to resolve the-fn."))
-              nil)))
-      identity))
+  (when the-fn
+    (cond
+      (fn? the-fn)       the-fn
+      (symbol? the-fn)   (let [the-fn-ref (var-get (requiring-resolve the-fn))]
+                           (if-not (fn? the-fn-ref)
+                             (throw (ex-info "`the-fn` must be an fn or a symbol that points to an fn."
+                                             {:the-fn the-fn}))
+                             the-fn-ref))
+      :else
+      (throw (ex-info "Unable to resolve `the-fn` to a function." {:the-fn the-fn})))))
 
 (defstrategy UpdateConsumedRecordKey
   [& {:keys [key-fn] :as params}]
   (when-not key-fn
-    (throw (ex-info "`key-fn` must have a value."
+    (throw (ex-info "In `UpdateConsumedRecordKey` strategy, `key-fn` parameter must have a value."
                     {:key-fn key-fn
                      :params params})))
   (let [key-fn' (resolve-fn key-fn)]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -325,7 +325,25 @@
        (apply ~n (rest strategy-specs#)))))
 
 
-;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defstrategy RenameTopicsForProducer
+  [& {:keys [rename-fn]}]
+  (when-not rename-fn
+    (throw (ex-info (str "strategy RenameTopicsForProducer requires the `rename-fn` to be specified. This function "
+                         "accepts a topic name for every message, and must return a modified version of the topic, "
+                         "OR nil, in which case the original topic value will be kept.")
+                    {})))
+  (reify
+    IProducerPreProduceMiddleware
+    (pre-produce-hook [_ msgs]
+      (map (fn [{:as   msg
+                 :keys [topic]}]
+             (assoc msg :topic (or (rename-fn topic)
+                                   topic)))
+           msgs))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- get-allowed-config-keys
     [config-class]

--- a/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
+++ b/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
@@ -12,8 +12,9 @@
 
 (s/def :topic-forwarder-cfg/msg-filter fn?)
 (s/def :topic-forwarder-cfg/msg-transform fn?)
-(s/def :topic-forwarder-cfg/topics (s/or :string-col     ::-kafka/topics
-                                         :topic-provider ::-kafka/topic-name-provider))
+(s/def :topic-forwarder-cfg/topics (s/or :string-col         ::-kafka/topics
+                                         :topic-provider     ::-kafka/topic-name-provider
+                                         :topic-provider-col (s/coll-of ::-kafka/topic-name-provider)))
 
 (s/def :topic-forwarder-cfg/src (s/and ::topic-forwarder-cluster-cfg
                                        (s/keys :req-un [:topic-forwarder-cfg/topics]
@@ -102,9 +103,11 @@
     :as                          config}]
   (assoc-in config [:src-cluster-cfg :topics]
             (case option-kw
-              :string-col     [:strategy/SubscribeWithTopicsCollection topics]
-              :topic-provider [:strategy/SubscribeWithTopicNameProvider
-                               :topic-name-providers [topics]])))
+              :string-col         [:strategy/SubscribeWithTopicsCollection topics]
+              :topic-provider     [:strategy/SubscribeWithTopicNameProvider
+                                   :topic-name-providers [topics]]
+              :topic-provider-col [:strategy/SubscribeWithTopicNameProvider
+                                   :topic-name-providers topics])))
 
 (defn create-system-config
   [& cfg]

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -107,17 +107,17 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn read-instance-id-values
-  "Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work."
-  []
-  (let [{:keys [status error body]}
-        @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
-    (if (or error (not= 200 status))
-      nil
-      (json/read-str body))))
+;; Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work.
+(def instance-id-values
+  (delay
+    (let [{:keys [status error body]}
+          @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
+      (if (or error (not= 200 status))
+        nil
+        (json/read-str body)))))
 
-(defmethod aero/reader 'ec2-instance-identity-value
-  [_ _ value] (get (read-instance-id-values) value))
+(defmethod aero/reader 'ec2/instance-identity-data
+  [_ _ value] (get @instance-id-values value))
 
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -1,11 +1,15 @@
 (ns afrolabs.config
-  (:require [aero.core :as aero]
-            [clojure.java.io :as io]
-            [clojure.string :as str]
-            [integrant.core :as ig]
-            [taoensso.timbre :as log]
-            [clojure.data.csv :as csv]
-            [clojure.edn :as edn]))
+  (:require
+   [aero.core :as aero]
+   [clojure.data.csv :as csv]
+   [clojure.edn :as edn]
+   [clojure.data.json :as json]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [integrant.core :as ig]
+   [org.httpkit.client :as http]
+   [taoensso.timbre :as log]
+   ))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -100,6 +104,20 @@
 (defmethod aero/reader 'ip-hostname
   [_ _ _value]
   (.getHostName (java.net.InetAddress/getLocalHost)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn read-instance-id-values
+  "Queries the EC2 instance metadata. This has a fixed IP-based URL. Returns \"not-ec2-instance\" if this call does not work."
+  []
+  (let [{:keys [status error body]}
+        @(http/get "http://169.254.169.254/latest/dynamic/instance-identity/document")]
+    (if (or error (not= 200 status))
+      nil
+      (json/read-str body))))
+
+(defmethod aero/reader 'ec2-instance-identity-value
+  [_ _ value] (get (read-instance-id-values) value))
 
 ;; #?(:clj (Long/parseLong (str value)))
 ;; #?(:cljs (js/parseInt (str value)))


### PR DESCRIPTION
# Improvements

### New strategy protocols
- `IProducerPreProduceMiddleware` - allows an intercept on kafka records immediately before those records are produced, allowing for behaviour like changing the topic a message is being sent to. This was useful in the forwarder, to fetch from one topic and forward to a topic with different name.
- `IConsumerMessagesPreProcessor` - allows an intercept on messages between the `Consumer` and the `:consumer/client`. This was used in ktable data for _Location Replay_ to pack data into records, which are much more memory efficient.

### topic-forwarder

- `:topics` parameter now additionally support _collection of topic-providers_ 

### aero configuration

- support for `#ec2/instante-identity-data` (example `#ec2/instance-identity-data "privateIp"`)

### ktable improvements

- new configuration parameter `:retention-ms` (used with new `:clock`), which:
  - limits how much data is loaded initially by seeking to an appropriate offset
  - expunges ktable records from the ktable, if their respective `:timestamp`s are older than this `:retention-ms` 
- re-arrange meta-data kept on ktables to keep `:offset`, `:partition`, `:headers` & `:timestamp` per record. This is kept in `:ktable/record-data`.
- soft-deprecate `:ktable/record-headers`