### PR TITLE
Maintenance

### DIFF
--- a/src/afrolabs/components.clj
+++ b/src/afrolabs/components.clj
@@ -19,6 +19,7 @@
      ))
 
 (defmacro defcomponent
+  "Defines a new component."
   [{::keys [config-spec ig-kw]}
    body-destruct
    & body]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -2125,7 +2125,7 @@
     "Waits until a ktable has consumed messages from its source topics, at least up to the topic-partition-offset data parameter.
 Supports a timeout operation. `timeout-duration` must be a java.time.Duration.")
   (ktable-wait-until-fully-current
-    [_this timeout-period timeout-value]
+    [_this timeout-duration timeout-value]
     "Waits until the current offset is also the latest offset. This might time out if there are still active producers to the ktable, and the consumer struggle to fully catch up as a result."))
 
 (s/def ::ktable #(satisfies? IKTable %))

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -45,7 +45,9 @@
   - You may optionally set `collect-messages?` to false, in which case no records will be returned. This is useful
     in streaming mode.
   - You may specify `stream-ch`, which will accept a collection of kafka messages. This is useful in conjunction with
-    setting `collect-messages?` to `false`. NOTE: `stream-ch` will be closed when consumption is done.
+    setting `collect-messages?` to `false`.
+    NOTE: `stream-ch` will be closed when consumption is done.
+    NOTE: The client-side may close `stream-ch`, at which point the consumer will stop.
 
   - use :extra-strategies is useful for specifying deserialization settings, seeking to offsets &c.
 
@@ -101,7 +103,8 @@
 
               ;; is streaming defined? if so, send it on
               (when stream-ch
-                (csp/>!! stream-ch msgs))
+                (when-not (csp/>!! stream-ch msgs)
+                  (deliver loaded-enough-msgs true)))
 
               ;; do we have enough yet? is anything ever enough?
               (when (and (not= nr-msgs :all)

--- a/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
+++ b/src/afrolabs/components/kafka/utilities/topic_forwarder.clj
@@ -146,7 +146,8 @@
                                          :strategies       (map second dest-strategies)}
                 ::-kafka/kafka-consumer {:bootstrap-server src-bootstrap-server
                                          :strategies       (let [r (concat (map second src-strategies)
-                                                                           [(ig/ref ::-kafka/kafka-producer)
+                                                                           [[:strategy/ProduceConsumerResultsWithProducer
+                                                                             (ig/ref ::-kafka/kafka-producer)]
                                                                             src-topics-strategy ;; unify-src-topics makes a strategy for use here
                                                                             ])]
                                                              r)


### PR DESCRIPTION
This change is primarily focused on the introduction of `ProduceConsumerResultsWithProducer` and implementing its use.

This is a strategy, through which a producer can be given to a consumer, in such a way that the producer is protected from early `halt`-ing. This fixes a long-standing bug, that was only tracked down now.

Edit:
Added code in `-kafka/consumer-main` that measure partition lag