### PR TITLE
Changes to allow Connecting to AWS' managed kafka offering, MSK [CU-8696ym168]

### DIFF
--- a/src/afrolabs/components/confluent.clj
+++ b/src/afrolabs/components/confluent.clj
@@ -14,6 +14,10 @@
   ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
   [& {:keys [api-key api-secret]}]
 
+  (log/info (str "Connection to kafka configured with ConfluentCloud strategy..."
+                 (when-not (and api-key api-secret)
+                   " (don't have api-key & api-secret.)")))
+
   (letfn [(merge-common
             [cfg]
             (cond-> cfg

--- a/src/afrolabs/components/kafka/msk.clj
+++ b/src/afrolabs/components/kafka/msk.clj
@@ -4,7 +4,7 @@
    [taoensso.timbre :as log]))
 
 
-(-kafka/defstrategy AwsMsk
+(-kafka/defstrategy AwsMskScram
   ;; "Sets the required and recommended config to connect to a kafka cluster in confluent cloud.
   ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
   [& {:aws.msk/keys [username password]}]

--- a/src/afrolabs/components/kafka/msk.clj
+++ b/src/afrolabs/components/kafka/msk.clj
@@ -9,7 +9,7 @@
   ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
   [& {:aws.msk/keys [username password]}]
 
-  (log/info (str "Connection to kafka configured with AwsMsk strategy..."
+  (log/info (str "Connection to kafka configured with AwsMskScram strategy..."
                  (when-not (and username password)
                    " (don't have username & password.)")))
 

--- a/src/afrolabs/components/kafka/msk.clj
+++ b/src/afrolabs/components/kafka/msk.clj
@@ -1,12 +1,17 @@
 (ns afrolabs.components.kafka.msk
   (:require
-   [afrolabs.components.kafka :as -kafka]))
+   [afrolabs.components.kafka :as -kafka]
+   [taoensso.timbre :as log]))
 
 
 (-kafka/defstrategy AwsMsk
   ;; "Sets the required and recommended config to connect to a kafka cluster in confluent cloud.
   ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
   [& {:aws.msk/keys [username password]}]
+
+  (log/info (str "Connection to kafka configured with AwsMsk strategy..."
+                 (when-not (and username password)
+                   " (don't have username & password.)")))
 
   (letfn [(merge-common
             [cfg]
@@ -54,6 +59,8 @@
 (-kafka/defstrategy AwsMskIam
   ;; "Sets the config to connect to a kafka cluster hosted in AWS MSK, using IAM authn/authz.
   [& {:as _cfg}]
+
+  (log/info "Connection to kafka configured with AwsMskIam strategy...")
 
   (letfn [(merge-common
             [cfg]

--- a/src/afrolabs/components/kafka/msk.clj
+++ b/src/afrolabs/components/kafka/msk.clj
@@ -1,0 +1,89 @@
+(ns afrolabs.components.kafka.msk
+  (:require
+   [afrolabs.components.kafka :as -kafka]))
+
+
+(-kafka/defstrategy AwsMsk
+  ;; "Sets the required and recommended config to connect to a kafka cluster in confluent cloud.
+  ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
+  [& {:aws.msk/keys [username password]}]
+
+  (letfn [(merge-common
+            [cfg]
+            (cond-> cfg
+              true
+              (merge {"client.dns.lookup"        "use_all_dns_ips"
+                      "reconnect.backoff.max.ms" "10000"
+                      "request.timeout.ms"       "30000"})
+
+              (and username (seq username)
+                   password (seq password))
+              (merge {;; "sasl.mechanism"           "PLAIN"
+                      "sasl.jaas.config"         (format (str "org.apache.kafka.common.security.scram.ScramLoginModule required "
+                                                              "username=\"%s\" "
+                                                              "password=\"%s\" "
+                                                              ";")
+                                                         username password)
+                      "security.protocol"        "SASL_SSL"
+                      "sasl.mechanism"           "SCRAM-SHA-512"
+                      })))]
+
+    (reify
+      -kafka/IUpdateConsumerConfigHook
+      (update-consumer-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"session.timeout.ms" "45000"})))
+
+      -kafka/IUpdateProducerConfigHook
+      (update-producer-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"acks"      "all"
+                    "linger.ms" "5"})))
+
+      -kafka/IUpdateAdminClientConfigHook
+      (update-admin-client-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"default.api.timeout.ms" "300000"}))))))
+
+(-kafka/defstrategy AwsMskIam
+  ;; "Sets the config to connect to a kafka cluster hosted in AWS MSK, using IAM authn/authz.
+  [& {:as _cfg}]
+
+  (letfn [(merge-common
+            [cfg]
+            (cond-> cfg
+              true
+              (merge {"sasl.jaas.config"                   "software.amazon.msk.auth.iam.IAMLoginModule required awsMaxRetries=\"7\" awsMaxBackOffTimeMs=\"500\";"
+                      "sasl.client.callback.handler.class" "software.amazon.msk.auth.iam.IAMClientCallbackHandler"
+                      "security.protocol"                  "SASL_SSL"
+                      "sasl.mechanism"                     "AWS_MSK_IAM"
+                      })))]
+
+    (reify
+      -kafka/IUpdateConsumerConfigHook
+      (update-consumer-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"session.timeout.ms" "45000"})))
+
+      -kafka/IUpdateProducerConfigHook
+      (update-producer-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"acks"      "all"
+                    "linger.ms" "5"})))
+
+      -kafka/IUpdateAdminClientConfigHook
+      (update-admin-client-cfg-hook
+          [_ cfg]
+        (-> cfg
+            (merge-common)
+            (merge {"default.api.timeout.ms" "300000"}))))))

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -26,7 +26,8 @@
            [java.util UUID]
            [afrolabs.components.kafka IPostConsumeHook IConsumerClient]
            [clojure.lang IDeref]
-           [org.apache.kafka.clients.admin ListTopicsOptions]))
+           [org.apache.kafka.clients.admin ListTopicsOptions]
+           ))
 
 (defn load-messages-from-confluent-topic
   "Loads a collection of messages from confluent kafka topics. Will stop consuming when the consumer has reached the
@@ -459,6 +460,8 @@
            :host      (.host node)}
     (.hasRack node) (assoc :rack (.rack node))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn describe-topics
   [admin-client topics]
   (let [partitions-info (->> (let [topics (-> @admin-client
@@ -661,3 +664,32 @@
       @system-must-stop
       (do-halt)
       @halted?)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn describe-acls
+  [& {:as admin-client-component}]
+
+  (-> @admin-client-component
+      (.describeAcls org.apache.kafka.common.acl.AclBindingFilter/ANY)
+      (.values)
+      (.get)))
+
+;; (defn create-acls!
+;;   "Idempotent because of api."
+;;   [admin-client-component
+;;    acls]
+
+;;   (.createAcls ^org.apache.kafka.clients.admin.Admin @admin-client-component
+;;                [(->> acls
+;;                      (map (fn [acl]
+;;                             (org.apache.kafka.common.acl.AclBinding.
+;;                              (org.apache.kafka.common.resource.ResourcePattern. org.apache.kafka.common.resource.ResourceType/USER
+;;                                                                                 "*"
+;;                                                                                 org.apache.kafka.common.resource.PatternType/)
+;;                              (org.apache.kafka.common.acl.AccessControlEntry. )))))])
+
+
+
+;;   )

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -140,7 +140,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmethod aero/reader 'config/pick
+(defmethod aero/reader 'config/case
   [_opts _ value]
   (when-not (odd? (count value))
     (throw (ex-info "Provide the case value and the cases as pairs." {})))

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -146,11 +146,8 @@
     (throw (ex-info "Provide the case value and the cases as pairs." {})))
   (let [[the-case & cases] value
         all-cases (into {} (map vec (partition 2 cases)))]
-    (or (get all-cases the-case)
-        (throw (ex-info "No case found"
-                        {:the-case  the-case
-                         :cases     cases
-                         :all-cases all-cases})))))
+    (get all-cases the-case) ;; might return nil...
+    ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -140,6 +140,20 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defmethod aero/reader 'config/pick
+  [_opts _ value]
+  (when-not (odd? (count value))
+    (throw (ex-info "Provide the case value and the cases as pairs." {})))
+  (let [[the-case & cases] value
+        all-cases (into {} (map vec (partition 2 cases)))]
+    (or (get all-cases the-case)
+        (throw (ex-info "No case found"
+                        {:the-case  the-case
+                         :cases     cases
+                         :all-cases all-cases})))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defonce static-parameter-sources (delay (merge (read-system-env)
                                                 (read-system-props))))
 


### PR DESCRIPTION
CU-8696ym168

- New AWS-focused kafka authentication strategies `:strategy/AwsMskIam` & `:strategy/AwsMskScram`.
- Extend -kafka-utils/delete-some-topics to accept an `:admin-client`
- Play a little with ACLs using kafka JVM API.
- Aero reader tag for `#config/case`, similar to `case` statements in programming languages.
