### PR TITLE
Pwab/support disable on components

### DIFF
--- a/src/afrolabs/components.clj
+++ b/src/afrolabs/components.clj
@@ -23,7 +23,7 @@
 
 (defmacro defcomponent
   "Defines a new component."
-  [{::keys [config-spec ig-kw supports?:disabled]}
+  [{::keys [config-spec ig-kw supports:disabled?]}
    body-destruct
    & body]
   (let [[cfg-sym] body-destruct
@@ -34,8 +34,8 @@
        (defn ~init-fn-name
          [cfg-key# cfg#]
 
-         (if (or (not ~supports?:disabled)
-                 (not (:disabled cfg#)))
+         (if (or (not ~supports:disabled?)
+                 (not (:disabled? cfg#)))
            (do
 
              ;; validation of config against config specification

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1505,7 +1505,7 @@
 
 (-comp/defcomponent {::-comp/ig-kw              ::kafka-consumer
                      ::-comp/config-spec        ::consumer-config
-                     ::-comp/supports?:disabled true}
+                     ::-comp/supports:disabled? true}
   [cfg] (make-consumer cfg))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -1503,8 +1503,9 @@
 
         ))))
 
-(-comp/defcomponent {::-comp/ig-kw       ::kafka-consumer
-                     ::-comp/config-spec ::consumer-config}
+(-comp/defcomponent {::-comp/ig-kw              ::kafka-consumer
+                     ::-comp/config-spec        ::consumer-config
+                     ::-comp/supports?:disabled true}
   [cfg] (make-consumer cfg))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -138,6 +138,11 @@
   [_ _ value]
   (config-string->bool value))
 
+(defmethod aero/reader 'not
+  [_ _ value]
+  (println (str "'not: " value))
+  (log/spy :debug (not (boolean value))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmethod aero/reader 'config/case

--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -140,8 +140,7 @@
 
 (defmethod aero/reader 'not
   [_ _ value]
-  (println (str "'not: " value))
-  (log/spy :debug (not (boolean value))))
+  (not (boolean value)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
It is sometimes useful not to have certain expensive (kafka) components run in every environment. Various hacks have been tried in the past, but really what we need is a way to entirely _disable_ a component (created with `defcomponent`) from even instantiating.

This MR adds support for `defcomponent`s to opt in to this behaviour using `::-comp/supports?:disabled` in the declaration like this:

```clj
(-comp/defcomponent {::-comp/ig-kw              ::kafka-consumer
                     ::-comp/config-spec        ::consumer-config
                     ::-comp/supports?:disabled true}
  [cfg] (make-consumer cfg))
```

Here is an example in telemetry where this is used:

```clj
 :afrolabs.gometro-bridge.mapon/consumer-client:mapon-integration
 {:disabled #not #bool #or [#option MAPON_INTEGRATION_ENABLED
                            "false"]
 ...}

 :afrolabs.gometro-bridge.mapon/consumer:mapon-integration
 {:disabled                        #ref [:afrolabs.gometro-bridge.mapon/consumer-client:mapon-integration :disabled]
 ...}
```

With this configuration if `MAPON_INTEGRATION_ENABLED` is not set (most existing environments) these two components will not start and retain `nil` state in the system component map. 

This also short-circuits component configuration validation.
