### PR TITLE
move defstrategy call for ByteArraySerializer into kafka namespace

### DIFF
--- a/src/afrolabs/components/kafka/bytes_serdes.clj
+++ b/src/afrolabs/components/kafka/bytes_serdes.clj
@@ -60,32 +60,4 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(-kafka/defstrategy ByteArraySerializer
-  [& {consumer-option :consumer
-      producer-option :producer
-      :or {consumer-option :none
-           producer-option :none}}]
-
-  ;; validation of arguments, fail early
-  (let [allowed-values #{:key :value :both :none}]
-    (when-not (and (allowed-values consumer-option)
-                   (allowed-values producer-option))
-      (throw (ex-info "Specify proper values for :consumer and/or :producer for ByteArraySerializer."
-                      {::allowed-values  allowed-values
-                       ::consumer-option consumer-option
-                       ::producer-option producer-option}))))
-
-  (reify
-    IUpdateConsumerConfigHook
-    (update-consumer-cfg-hook
-        [_ cfg]
-      (cond-> cfg
-        (#{:both :key}   consumer-option)  (assoc ConsumerConfig/KEY_DESERIALIZER_CLASS_CONFIG    "afrolabs.components.kafka.bytes_serdes.Deserializer")
-        (#{:both :value} consumer-option)  (assoc ConsumerConfig/VALUE_DESERIALIZER_CLASS_CONFIG  "afrolabs.components.kafka.bytes_serdes.Deserializer")))
-
-    IUpdateProducerConfigHook
-    (update-producer-cfg-hook
-        [_ cfg]
-      (cond-> cfg
-        (#{:both :key}   producer-option) (assoc ProducerConfig/KEY_SERIALIZER_CLASS_CONFIG       "afrolabs.components.kafka.bytes_serdes.Serializer")
-        (#{:both :value} producer-option) (assoc ProducerConfig/VALUE_SERIALIZER_CLASS_CONFIG     "afrolabs.components.kafka.bytes_serdes.Serializer")))))
+;; (defonce initialised (atom nil))

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -666,13 +666,13 @@
                                    (-confluent/ConfluentCloud :api-key confluent-api-key
                                                               :api-secret confluent-api-secret))])
         admin-client-strategies common-strategies
-        src-topic-consumer-strategies (concat [(-bytes-serdes/ByteArraySerializer :consumer :both)
+        src-topic-consumer-strategies (concat [(-kafka/ByteArraySerializer :consumer :both)
                                                (-kafka/OffsetReset "earliest")
                                                (-kafka/ConsumerGroup consumer-group-id)
                                                (-kafka/SubscribeWithTopicsCollection [src-topic])
                                                (-kafka/AutoCommitOffsets)]
                                               common-strategies)
-        dest-topic-producer-strategies (concat [(-bytes-serdes/ByteArraySerializer :producer :both)
+        dest-topic-producer-strategies (concat [(-kafka/ByteArraySerializer :producer :both)
                                                 (-kafka/HighThroughput)]
                                                common-strategies)
 


### PR DESCRIPTION
With this class (BytesSerdes for kafka) also being aot-ed, there's something weird happening with repl-time where the namespace is not loaded correctly. The change in this MR makes it reliable to start a system from the repl, without first having to manually re-load some namespace in the afrolabs-clj library for ByteArraySerdes to be able to work.

This only impacts the project repl.