### PR TITLE
Feature/bri 507 telemetry job http apis

### DIFF
--- a/src/afrolabs/components/confluent.clj
+++ b/src/afrolabs/components/confluent.clj
@@ -14,9 +14,9 @@
   ;; Based on: https://docs.confluent.io/cloud/current/client-apps/config-client.html#java-client"
   [& {:keys [api-key api-secret]}]
 
-  (log/info (str "Connection to kafka configured with ConfluentCloud strategy..."
-                 (when-not (and api-key api-secret)
-                   " (don't have api-key & api-secret.)")))
+  (log/debug (str "Connection to kafka configured with ConfluentCloud strategy..."
+                  (when-not (and api-key api-secret)
+                    " (don't have api-key & api-secret.)")))
 
   (letfn [(merge-common
             [cfg]

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -2209,7 +2209,7 @@ Supports a timeout operation. `timeout-duration` must be a java.time.Duration.")
   (ktable-wait-until-fully-current [_this timeout-duration timeout-value]
     "Waits until the current offset is also the latest offset. This might time out if there are still active producers to the ktable, and the consumer struggle to fully catch up as a result.")
   (ktable-subscribe [_this {:keys [xducer
-                                   sliding-buffer-size]}]
+                                   receiving-ch]}]
     "Subscribes to (processed) events stream for the kafka messages that make up the state of the ktable.
 
 If `xducer` is nil, it will become identity, which means all messages will arrive in firehose fashion.


### PR DESCRIPTION
## Allow to subscribe to ktable kafka messages

- Update the `IKTable` protocol to include `subscribe`/`unsubscribe`
- This is core.async channels implementation for receiving the kafka messages that build into the ktable value
- Subscription happens with transducers that filter and otherwise transform the values posted onto the channels

This mechanism implemented for Bridge "jobs" / "tasks", as an alternative mechanism for populating KTable record
value websockets.

## Confluent Connection strategy logs itself as `DEBUG` (and not `INFO` any longer)

This reduces the amount of semi-useless logs on startup.