### PR TITLE
Maintenance

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((cider-clojure-cli-aliases . ":repl"))))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`afrolabs-clj` is a Clojure library of reusable [Integrant](https://github.com/weavejester/integrant) components for Afrolabs microservices. It provides opinionated, production-ready components for HTTP, Kafka, AWS, health management, observability, and configuration.
+
+## Commands
+
+```bash
+# AOT-compile Kafka serializers and Lambda runtime (required before using as a library)
+clojure -M:build/task compile-aot
+
+# Clean build artifacts
+clojure -M:build/task clean
+
+# Display build configuration
+clojure -M:build/task config
+
+# Vulnerability scan
+clojure -M:build/nvd-vulnerabilities scan -p deps.edn
+
+# Run tests (no test alias defined — use cognitect test runner directly)
+clojure -X:test
+
+# REPL
+clojure -M:repl  # or just: clj
+```
+
+There is no dedicated test runner alias in `deps.edn`. The single test file is `test/afrolabs/components/kafka_test.clj`.
+
+**AOT compilation is required** (via `:deps/prep-lib`) because Kafka serializer classes must exist as compiled `.class` files in `target/classes/` to be loadable by the JVM at runtime.
+
+At the time of writing Java 25 and Clojure 1.12.4 are used (see `.tool-versions` which uses `asdf` to specify authoritive versions for dependencies).
+
+## Architecture
+
+### Component System (`afrolabs.components`)
+
+The main benefit of the component system is that it allows client applications to use the `(ns-alias/redeclare-* ::new-component-integrant-key)` macros to allow multiple distinct instances of the same component in client integrant configurations. This is in addition to the default integrant component keyword that the component is declared with.
+
+For some components this is useful, like kafka consumers, producers, and the http server component, which is often used twice like below example. 
+
+#### Component Usage Example
+
+Using the http component twice in one integrant config.
+
+```clojure
+(ns some-ns
+  (:require [afrolabs.components.http :as -http]))
+  
+(-http/redeclare-service ::http)
+(-http/redeclare-service ::http-internal)
+```
+
+with corresponding example client `config.edn` snippets:
+```clojure
+ :some-ns/http-internal
+ {:handlers [#ig/ref :afrolabs.prometheus/metrics-endpoint
+             #ig/ref :afrolabs.components.http/health-endpoint
+             #ig/ref :afrolabs.gometro-bridge.geofences.alerts.common/fake-geofence-alerts-callback
+             #ig/ref :afrolabs.gometro-bridge.callback/component]
+  :port     #ref [:afrolabs.gometro-bridge.core/common-http-config :internal-port]
+  :ip       #ref [:afrolabs.gometro-bridge.core/common-http-config :internal-ip]}
+
+ :some-ns/http
+ {:handlers             [#ig/ref :afrolabs.components.http/health-endpoint
+                         #ig/ref :afrolabs.gometro-bridge.v2.rest/v2-http-api
+
+                         #ig/ref :afrolabs.gometro-bridge.data-model.schemas/component
+                         #ig/ref :afrolabs.gometro-bridge.docs/http-handler
+
+                         #ig/ref :afrolabs.gometro-bridge.four-oh-four/component]
+  :middleware-providers [#ig/ref :afrolabs.components.http/git-version-middleware]
+  :port                 #long #or [#option HTTP_PORT
+                                   "8000"]
+  :ip                   #or [#option HTTP_IP
+                             "127.0.0.1"]}
+```
+
+All components use the `defcomponent` macro, which wraps Integrant's `init-key`/`halt-key!` multimethods. It auto-validates config against a `clojure.spec.alpha` spec and supports optional `:disabled?` config:
+
+```clojure
+(defcomponent {::config-spec ::my-cfg-spec
+               ::ig-kw       ::my-component
+               ::supports:disabled? true}
+  [cfg]
+  (reify
+    IHaltable
+    (halt [_] ...)))
+```
+
+All stoppable components implement `IHaltable`. The `defcomponent` macro handles both init and halt registration.
+
+### Service Bootstrap (`afrolabs.service`)
+
+`as-system` and `as-service` bootstrap a full Integrant system from a `config.edn` file. Config is read via `afrolabs.config/read-config`, which supports Aero with custom tag readers:
+
+Custom readers defined in `afrolabs.config` (not exhaustive):
+
+- `#ref [:component-key :attribute]` — reference a specific attribute from another component's config map
+- `#ig/ref` — Integrant ref (for use inside Aero config files)
+- `#parameter` — env var or Java system property
+- `#option` — optional parameter (nil if missing)
+- `#long?` / `#int?` — parse numeric strings
+- `#regex` — compile a regex pattern
+- `#csv-array` — comma-separated string to vector
+- `#edn` — parse an EDN string
+- `#ip-hostname` — validate hostname/IP
+- `#ec2/instance-identity-data` — fetch EC2 instance metadata
+- `#bool` — coerce string to boolean
+- `#not` — boolean negation
+
+### Key Components
+
+**Health (`afrolabs.components.health`):** Manages service lifecycle. Implements `IServiceHealthTripSwitch` — components can signal unhealthy state. Handles `SIGINT`/`SIGTERM` via `beckon`. `wait-while-healthy` blocks until shutdown.
+
+**HTTP (`afrolabs.components.http`):** http-kit server with reitit routing. Components participate via `IHttpRequestHandler` (for routes) and `IRingMiddlewareProvider` (for middleware). Request IDs are injected into every request and the Timbre logging context.
+
+**Kafka (`afrolabs.components.kafka`):** Consumer, producer, and admin client wrappers. Connection strategy is configured via the `defstrategy` macro — strategies implement `IUpdateConsumerConfigHook`, `IUpdateProducerConfigHook`, or `IUpdateAdminClientConfigHook`. Built-in strategies include `ConfluentCloud`, `AdhocConfig`, `MSK`. Multiple strategies can be composed. Available serialization formats: JSON, EDN, Transit, Nippy, Bytes, Dynamic JSON, Schema Registry–compatible.
+
+**AWS (`afrolabs.components.aws`):** Cognitect AWS SDK wrappers for SNS, SQS, S3, SSO, STS, Cognito, CloudWatch Logs. `backoff-and-retry-on-rate-exceeded` macro handles AWS throttling. EC2 instance metadata is available via `afrolabs.config`.
+
+**Prometheus (`afrolabs.prometheus`):** iapetos-based metrics. `register-metric` macro registers metrics with a registry component. The HTTP metrics endpoint is a separate component providing `/metrics`.
+
+**Logging (`afrolabs.logging`):** Timbre with structured context. Use `log/with-context+` to attach key-value pairs to all log calls within a scope. JSON appender support for cloud logging.
+
+### Extension Protocols
+
+Protocols use `:extend-via-metadata true` throughout, enabling lightweight extension without `reify`:
+
+```clojure
+(def my-handler
+  (with-meta {}
+    {`IHttpRequestHandler/ring-handler (fn [_] my-ring-fn)}))
+```
+
+### Async / Stream Processing (`afrolabs.csp`)
+
+`core.async` channels with transducer support. `partition-by-interval` provides time-windowed batching. xforms transducers are used extensively in Kafka consumers for stream processing.
+
+### Utilities
+
+- `afrolabs.utils`: `condas->` (conditional threading with binding), `opt-assoc` (optional map update), `time` (log execution duration)
+- `afrolabs.transit`: Transit read/write helpers
+- `afrolabs.spec`: `assert!` helper
+- `afrolabs.user`: REPL helpers (loaded automatically in dev)
+
+## Kafka Serializers Require AOT
+
+The Kafka serializers (`json-serdes`, `edn-serdes`, `bytes-serdes`, `transit-serdes`, `nippy`, `schema-registry-compatible-serdes`) and `spicyrun.ninja.lambda.runtime` **must be AOT-compiled** to `.class` files. The `:deps/prep-lib` key in `deps.edn` ensures `compile-aot` runs when the library is used as a dependency.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,13 +10,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 # AOT-compile Kafka serializers and Lambda runtime (required before using as a library)
-clojure -M:build/task compile-aot
+clojure -T:build/task compile-aot
 
 # Clean build artifacts
-clojure -M:build/task clean
+clojure -T:build/task clean
 
 # Display build configuration
-clojure -M:build/task config
+clojure -T:build/task config
 
 # Vulnerability scan
 clojure -M:build/nvd-vulnerabilities scan -p deps.edn

--- a/deps.edn
+++ b/deps.edn
@@ -9,10 +9,10 @@
   ;; org.eclipse.jetty/jetty-http                           {:mvn/version "9.4.58.v20250814"},
   ;; org.eclipse.jetty/jetty-client                         {:mvn/version "9.4.58.v20250814"},
   camel-snake-kebab/camel-snake-kebab                    {:mvn/version "0.4.3"},
-  metosin/jsonista                                       {:mvn/version "0.3.14",
+  metosin/jsonista                                       {:mvn/version "1.0.0",
                                                           :exclusions  [com.fasterxml.jackson.core/jackson-core]},
   failjure/failjure                                      {:mvn/version "2.3.0"},
-  org.clojure/core.async                                 {:mvn/version "1.8.741"},
+  org.clojure/core.async                                 {:mvn/version "1.9.865"},
   net.cgrand/xforms                                      {:mvn/version "0.19.6"},
   com.rpl/specter                                        {:mvn/version "1.1.6"},
   integrant/integrant                                    {:mvn/version "1.0.1"},
@@ -33,15 +33,15 @@
   io.prometheus/simpleclient                             {:mvn/version "0.16.0"},
   io.prometheus/simpleclient_hotspot                     {:mvn/version "0.16.0"},
   clj-commons/iapetos                                    {:mvn/version "0.1.14"},
-  com.cognitect.aws/api                                  {:mvn/version "0.8.800"},
-  com.cognitect.aws/endpoints                            {:mvn/version "871.2.42.9"},
+  com.cognitect.aws/api                                  {:mvn/version "0.8.812"},
+  com.cognitect.aws/endpoints                            {:mvn/version "871.2.42.29"},
   com.cognitect.aws/sns                                  {:mvn/version "871.2.32.15"},
   com.cognitect.aws/sqs                                  {:mvn/version "871.2.34.1"},
-  com.cognitect.aws/s3                                   {:mvn/version "871.2.41.20"},
-  com.cognitect.aws/monitoring                           {:mvn/version "871.2.42.4"},
-  com.cognitect.aws/logs                                 {:mvn/version "871.2.42.9"},
+  com.cognitect.aws/s3                                   {:mvn/version "871.2.42.29"},
+  com.cognitect.aws/monitoring                           {:mvn/version "871.2.42.29"},
+  com.cognitect.aws/logs                                 {:mvn/version "871.2.42.29"},
   nrepl/nrepl                                            {:mvn/version "1.6.0"},
-  com.taoensso/encore                                    {:mvn/version "3.159.0"},
+  com.taoensso/encore                                    {:mvn/version "3.160.1"},
   com.taoensso/timbre                                    {:mvn/version "6.8.0"},
   org.clojure/data.json                                  {:mvn/version "2.5.2"},
   org.clojure/data.csv                                   {:mvn/version "1.1.1"},
@@ -54,8 +54,8 @@
   org.slf4j/jcl-over-slf4j                               {:mvn/version "2.0.17"},
   com.fzakaria/slf4j-timbre                              {:mvn/version "0.4.1"},
   viesti/timbre-json-appender                            {:mvn/version "0.2.14"},
-  com.fasterxml.jackson.core/jackson-databind            {:mvn/version "2.21.1"},
-  com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.21.1"},
+  com.fasterxml.jackson.core/jackson-databind            {:mvn/version "2.21.2"},
+  com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.21.2"},
   com.google.re2j/re2j                                   {:mvn/version "1.8"},
   org.bouncycastle/bcpkix-jdk18on                        {:mvn/version "1.83"},
   ch.qos.reload4j/reload4j                               {:mvn/version "1.2.26"},
@@ -77,7 +77,7 @@
   lambdaisland/uri                                       {:mvn/version "1.19.155"},
   org.clj-commons/hickory                                {:mvn/version "0.7.7"},
   instaparse/instaparse                                  {:mvn/version "1.5.0"},
-  com.cognitect/transit-clj                              {:mvn/version "1.1.347"}
+  com.cognitect/transit-clj                              {:mvn/version "1.1.357"}
 
   com.velisco/tagged                                     {:mvn/version "0.5.0"}
   com.github.sikt-no/clj-jwt                             {:mvn/version "0.5.107"}
@@ -90,7 +90,7 @@
   com.github.oliyh/martian-httpkit  {:mvn/version "0.2.2"}
 
   ;; NippySerializer strategy for kafka*
-  com.taoensso/nippy             {:mvn/version "3.6.0"}
+  com.taoensso/nippy             {:mvn/version "3.6.2"}
 }
 
  :paths         ["src" "resources" "target/classes"]

--- a/deps.edn
+++ b/deps.edn
@@ -82,9 +82,14 @@
   com.velisco/tagged                                     {:mvn/version "0.5.0"}
   com.github.sikt-no/clj-jwt                             {:mvn/version "0.5.107"}
 
-  com.potetm/fusebox {:mvn/version "1.0.11"}
+  ;; reliability
+  com.potetm/fusebox                {:mvn/version "1.0.11"}
 
-  ;; NippySerializer strategy
+  ;; openapi client-side
+  com.github.oliyh/martian          {:mvn/version "0.2.2"}
+  com.github.oliyh/martian-httpkit  {:mvn/version "0.2.2"}
+
+  ;; NippySerializer strategy for kafka*
   com.taoensso/nippy             {:mvn/version "3.6.0"}
 }
 

--- a/deps.edn
+++ b/deps.edn
@@ -111,7 +111,11 @@
                  :build/nvd-vulnerabilities ;; run with `clojure -M:build/nvd-vulnerabilities scan -p deps.edn`
                  {:replace-deps {io.github.clj-holmes/clj-watson
                                  {:git/tag "v6.0.1" :git/sha "b520351"}}
-                  :main-opts    ["-m" "clj-watson.cli"]}}
+                  :main-opts    ["-m" "clj-watson.cli"]}
+
+                 :repl
+                 {:extra-deps {djblue/portal            {:mvn/version "0.64.0"}
+                               criterium/criterium      {:mvn/version "0.4.6"}}}}
 
 
  }

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {org.clojure/spec.alpha                                 {:mvn/version "0.6.249"},
-  org.clojure/clojure                                    {:mvn/version "1.12.4"},
+  org.clojure/clojure                                    {:mvn/version "1.12.5"},
   ;; com.google.javascript/closure-compiler-unshaded {:mvn/version "v20240317"},
   ;; org.clojure/clojurescript {:mvn/version "1.11.132", :exclusions [com.cognitect/transit-java]},
   org.clojure/test.check                                 {:mvn/version "1.1.3"},
@@ -23,7 +23,7 @@
   buddy/buddy-hashers                                    {:mvn/version "2.0.167"},
   buddy/buddy-auth                                       {:mvn/version "3.0.323"},
   buddy/buddy-sign                                       {:mvn/version "3.6.1-359"},
-  ring/ring-core                                         {:mvn/version "1.15.3"},
+  ring/ring-core                                         {:mvn/version "1.15.4"},
   metosin/ring-http-response                             {:mvn/version "0.9.5"},
   metosin/reitit                                         {:mvn/version "0.10.1",
                                                           :exclusions  [com.fasterxml.jackson.core/jackson-core]},
@@ -33,15 +33,15 @@
   io.prometheus/simpleclient                             {:mvn/version "0.16.0"},
   io.prometheus/simpleclient_hotspot                     {:mvn/version "0.16.0"},
   clj-commons/iapetos                                    {:mvn/version "0.1.14"},
-  com.cognitect.aws/api                                  {:mvn/version "0.8.812"},
-  com.cognitect.aws/endpoints                            {:mvn/version "871.2.42.29"},
+  com.cognitect.aws/api                                  {:mvn/version "0.8.824"},
+  com.cognitect.aws/endpoints                            {:mvn/version "871.2.44.12"},
   com.cognitect.aws/sns                                  {:mvn/version "871.2.32.15"},
   com.cognitect.aws/sqs                                  {:mvn/version "871.2.34.1"},
-  com.cognitect.aws/s3                                   {:mvn/version "871.2.42.29"},
-  com.cognitect.aws/monitoring                           {:mvn/version "871.2.42.29"},
-  com.cognitect.aws/logs                                 {:mvn/version "871.2.42.29"},
-  nrepl/nrepl                                            {:mvn/version "1.6.0"},
-  com.taoensso/encore                                    {:mvn/version "3.160.1"},
+  com.cognitect.aws/s3                                   {:mvn/version "871.2.43.0"},
+  com.cognitect.aws/monitoring                           {:mvn/version "871.2.44.1"},
+  com.cognitect.aws/logs                                 {:mvn/version "871.2.44.8"},
+  nrepl/nrepl                                            {:mvn/version "1.7.0"},
+  com.taoensso/encore                                    {:mvn/version "3.161.0"},
   com.taoensso/timbre                                    {:mvn/version "6.8.0"},
   org.clojure/data.json                                  {:mvn/version "2.5.2"},
   org.clojure/data.csv                                   {:mvn/version "1.1.1"},
@@ -49,25 +49,25 @@
   org.clojure/core.rrb-vector                            {:mvn/version "0.2.1"},
   fipp/fipp                                              {:mvn/version "0.6.29"},
   metosin/malli                                          {:mvn/version "0.20.1"},
-  org.slf4j/log4j-over-slf4j                             {:mvn/version "2.0.17"},
-  org.slf4j/jul-to-slf4j                                 {:mvn/version "2.0.17"},
-  org.slf4j/jcl-over-slf4j                               {:mvn/version "2.0.17"},
+  org.slf4j/log4j-over-slf4j                             {:mvn/version "2.0.18"},
+  org.slf4j/jul-to-slf4j                                 {:mvn/version "2.0.18"},
+  org.slf4j/jcl-over-slf4j                               {:mvn/version "2.0.18"},
   com.fzakaria/slf4j-timbre                              {:mvn/version "0.4.1"},
   viesti/timbre-json-appender                            {:mvn/version "0.2.14"},
-  com.fasterxml.jackson.core/jackson-databind            {:mvn/version "2.21.2"},
-  com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.21.2"},
+  com.fasterxml.jackson.core/jackson-databind            {:mvn/version "2.21.4"},
+  com.fasterxml.jackson.datatype/jackson-datatype-jsr310 {:mvn/version "2.21.4"},
   com.google.re2j/re2j                                   {:mvn/version "1.8"},
-  org.bouncycastle/bcpkix-jdk18on                        {:mvn/version "1.83"},
+  org.bouncycastle/bcpkix-jdk18on                        {:mvn/version "1.84"},
   ch.qos.reload4j/reload4j                               {:mvn/version "1.2.26"},
   org.javassist/javassist                                {:mvn/version "3.30.2-GA"},
-  joda-time/joda-time                                    {:mvn/version "2.14.1"},
+  joda-time/joda-time                                    {:mvn/version "2.14.2"},
   org.apache.kafka/kafka-clients                         {:mvn/version "8.2.0-ce"}
   #_#_io.confluent.ksql/ksqldb-api-client                {:mvn/version "7.6.0",
                                                           :exclusions
                                                           [org.slf4j/slf4j-log4j12
                                                            org.bouncycastle/bc-fips
                                                            org.javassist/javassist]},
-  org.slf4j/slf4j-api                                    {:mvn/version "2.0.17"},
+  org.slf4j/slf4j-api                                    {:mvn/version "2.0.18"},
   io.confluent/confluent-log4j                           {:mvn/version "1.2.17-cp2.2"},
   ;; thheller/shadow-cljs {:mvn/version "2.28.11"},
   gsnewmark/ring-pratchett                               {:mvn/version "0.1.0"},
@@ -80,17 +80,21 @@
   com.cognitect/transit-clj                              {:mvn/version "1.1.357"}
 
   com.velisco/tagged                                     {:mvn/version "0.5.0"}
-  com.github.sikt-no/clj-jwt                             {:mvn/version "0.5.107"}
+  com.github.sikt-no/clj-jwt                             {:mvn/version "0.5.109"}
 
   ;; reliability
   com.potetm/fusebox                {:mvn/version "1.0.11"}
 
   ;; openapi client-side
-  com.github.oliyh/martian          {:mvn/version "0.2.2"}
-  com.github.oliyh/martian-httpkit  {:mvn/version "0.2.2"}
+  com.github.oliyh/martian          {:mvn/version "0.2.3"}
+  com.github.oliyh/martian-httpkit  {:mvn/version "0.2.3"}
 
   ;; NippySerializer strategy for kafka*
   com.taoensso/nippy             {:mvn/version "3.6.2"}
+
+  ;; datasets, with a version override for owasp vuln
+  techascent/tech.ml.dataset {:mvn/version "8.023"}
+  com.techascent/tmd-parquet {:mvn/version "1.001"}
 }
 
  :paths         ["src" "resources" "target/classes"]

--- a/src/afrolabs/components/CLAUDE.md
+++ b/src/afrolabs/components/CLAUDE.md
@@ -1,0 +1,329 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`afrolabs.components.kafka` is the Kafka namespace. It defines the three core Integrant components (`::kafka-consumer`, `::kafka-producer`, `::admin-client`) and the full strategy system that configures them. Everything from serdes to topic subscription to offset management is a strategy.
+
+## Integrant Components
+
+All three support `:disabled? true` in their config maps.
+
+| Component keyword | Factory fn | Config spec |
+|---|---|---|
+| `::kafka-consumer` | `make-consumer` | `::consumer-config` |
+| `::kafka-producer` | `make-producer` | `::producer-config` |
+| `::admin-client` | `make-admin-client` | `::admin-client-cfg` |
+| `::ktable` | (inline) | `::ktable-cfg` |
+| `::topic-asserter` | (inline) | `::topic-asserter-cfg` |
+| `::ktable-asserter` | (inline) | `::ktable-asserter-cfg` |
+| `::list-of-topics` | (inline) | `::list-of-topics-cfg` |
+
+The factory functions (`make-consumer`, `make-producer`, `make-admin-client`) can also be called directly for ad-hoc / REPL use, outside of Integrant.
+
+### Consumer config shape
+
+```clojure
+{:bootstrap-server            "broker:9092"
+ :service-health-trip-switch  health-component  ;; required
+ :consumer/client             consumer-client   ;; required — implements IConsumerClient
+ :strategies                  [...]             ;; optional
+ :consumer.poll/timeout       1000}             ;; optional, ms
+```
+
+### Producer config shape
+
+```clojure
+{:bootstrap-server "broker:9092"
+ :strategies       [...]}
+```
+
+### `IConsumerClient`
+
+The single protocol a consumer caller must implement:
+
+```clojure
+(reify IConsumerClient
+  (consume-messages [_ msgs]
+    ;; msgs is a vector of maps: {:topic :partition :offset :key :value :timestamp :headers}
+    ;; return value: nil, or a collection of producer message maps to be forwarded
+    ))
+```
+
+## Strategy System
+
+Strategies are the primary extension point. A strategy is an object that may implement one or more of these protocols:
+
+| Protocol | Effect |
+|---|---|
+| `IUpdateConsumerConfigHook` | Modifies the raw Kafka consumer properties map before the consumer is created |
+| `IUpdateProducerConfigHook` | Same for producer |
+| `IUpdateAdminClientConfigHook` | Same for admin client |
+| `IConsumerInitHook` | Called with the `Consumer` object before the first `.poll` (used for `.subscribe`) |
+| `IConsumerPostInitHook` | Called after `IConsumerInitHook`, before first `.poll` (used for seeking) |
+| `IPostConsumeHook` | Called after each `.poll` cycle with the consumer and consumed records |
+| `IShutdownHook` | Called when the consumer poll loop exits |
+| `IConsumerMiddleware` | Intercepts messages between the poll loop and `IConsumerClient` |
+| `IConsumerMessagesPreProcessor` | Intercepts and mutates messages before `consume-messages` is called |
+| `IConsumedResultsHandler` | Handles the return value of `consume-messages` (e.g. to forward to a producer) |
+| `IProducerPreProduceMiddleware` | Intercepts messages before `.send` |
+
+The `defstrategy` macro defines both a constructor function and a `create-strategy` multimethod dispatch, so strategies can be instantiated either as function calls or as keyword vectors in config files:
+
+```clojure
+;; function call form (Clojure code)
+(JsonSerializer :consumer :value)
+
+;; keyword vector form (config.edn / strategies list)
+[:strategy/JsonSerializer :consumer :value]
+```
+
+`normalize-strategies` converts a mixed seq of either form into protocol-implementing objects.
+
+## Built-in Strategies (not exhaustive)
+
+**Serialization** — all accept `:consumer` and/or `:producer` with values `:key`, `:value`, or `:both`:
+- `StringSerializer` — `org.apache.kafka.common.serialization.String*`
+- `JsonSerializer` — AOT-compiled `json_serdes`; accepts `:deserialize-keys-as-keyword? true`
+- `EdnSerializer` — AOT-compiled `edn_serdes`; accepts `:parse-inst-as-java-time true`
+- `ByteArraySerializer` — raw byte arrays, AOT-compiled `bytes_serdes`
+- `TransitSerializer` — AOT-compiled `transit_serdes`
+- `NippySerializer` — AOT-compiled nippy
+
+**Subscription:**
+- `SubscribeWithTopicsCollection [topics]` — subscribe to a literal list of topic strings
+- `SubscribeWithTopicsRegex [regex]` — subscribe by regex pattern
+- `SubscribeWithTopicNameProvider :topic-name-providers [...]` — subscribe via `ITopicNameProvider` objects
+
+**Offset control:**
+- `OffsetReset "earliest"|"latest"` — sets `auto.offset.reset`
+- `AutoCommitOffsets` — enables auto-commit (default 30s interval)
+- `FreshConsumerGroup` — generates a random UUID consumer group
+- `ConsumerGroup consumer-group-id` — sets a fixed consumer group
+- `SeekToTimestampOffset offset` — seeks all partitions to a timestamp after partition assignment
+- `SeekToPartitionOffset topic-partition-offsets` — seeks to specific partition offsets
+
+**Caught-up detection:**
+- `CaughtUpNotifications & chs` — sends current offsets to provided channel(s) whenever the consumer is fully current (runs on every poll); multiple fire events
+- `CaughtUpOnceNotifications & chs` — fires once when the consumer catches up to the offsets that existed when it started
+
+**Performance:**
+- `HighThroughput` — bumps fetch sizes, poll records, batch size, linger, buffer, compression
+- `ProducerBatching :batch-size :linger-ms` — tune producer batching independently
+- `ProducerCompression [type]` — set producer compression (default `"lz4"`)
+- `ReduceRebalanceFrequency` — increases request timeout and heartbeat interval
+
+**Misc:**
+- `AdhocConfig & config-pairs` — directly set any valid Kafka config key/value; automatically routes each key to the correct client type (consumer/producer/admin)
+- `ClientId client-id` — sets `client.id` on both consumer and producer
+- `ConsumerMaxPollRecords n` — sets `max.poll.records`
+- `RequestTimeout ms`
+- `ProduceConsumerResultsWithProducer producer` — an `IConsumedResultsHandler` that forwards `consume-messages` return values to a producer
+- `RenameTopicsForProducer :rename-fn f` — an `IProducerPreProduceMiddleware` that rewrites topic names before producing
+- `UpdateConsumedRecordKey :key-fn f` — pre-processor that transforms the `:key` of each consumed message
+- `UpdateConsumedRecordValue :value-fn f` — pre-processor that transforms the `:value`
+
+## Topic Management
+
+- `assert-topics!` / `assert-topics` (deprecated) — creates missing topics; optionally increases partition count
+- `delete-topics!` — deletes topics that exist
+- `::topic-asserter` component — runs `assert-topics!` at system init time
+- `::ktable-asserter` component — like `topic-asserter` but also enforces `cleanup.policy` for compacted topics (supports `"compact"`, `"compact,delete"`)
+- `::list-of-topics` component — wraps a list of topic strings as an `ITopicNameProvider`, for use as an Integrant ref in `:topic-name-providers`
+
+## KTable (`::ktable`)
+
+A KTable is a consumer that maintains an in-memory snapshot of the latest value per key across its subscribed topics. It implements both `IDeref` (returns current state map) and `IKTable`:
+
+- `ktable-wait-for-catchup` — blocks until the ktable has consumed up to specified topic-partition offsets
+- `ktable-wait-until-fully-current` — blocks until the ktable is at the latest offset
+- `ktable-subscribe / ktable-unsubscribe` — subscribe to the stream of processed messages with an optional transducer
+
+KTable config requires `::ktable-id` (a unique string) and a `:clock` component (from `afrolabs.components.time`). Optionally supports `::ktable-checkpoint-storage` to persist and resume from offset checkpoints.
+
+## `redeclare-*` Macros
+
+Every `defcomponent` generates a `redeclare-<component-name>` macro that re-registers the same init/halt logic under a new Integrant keyword. This allows multiple independent instances of the same component type in one Integrant system:
+
+```clojure
+(ns my-app
+  (:require [afrolabs.components.kafka :as -kafka]))
+
+;; register ::my-app/consumer-a and ::my-app/consumer-b
+;; as two independent kafka-consumer instances
+(-kafka/redeclare-kafka-consumer ::my-app/consumer-a)
+(-kafka/redeclare-kafka-consumer ::my-app/consumer-b)
+```
+
+## Producer Message Map
+
+```clojure
+{:topic     "my-topic"   ;; required
+ :value     ...          ;; required
+ :key       ...          ;; optional
+ :headers   {...}        ;; optional, map of string -> any
+ :delivered-ch (csp/chan)} ;; optional — receives delivery ack or exception
+```
+
+Produce via `(produce! producer-component [msg1 msg2 ...])`.
+
+## Configuration Patterns in config.edn
+
+The following patterns appear consistently across production config files.
+
+### Shared Kafka config via `#ref`
+
+Rather than repeating bootstrap-server and auth strategy in every component, a single plain-data config component is used as a shared reference. Note the use of `#ref` (access a value inside a component's config map) vs `#ig/ref` (reference the component object itself):
+
+```clojure
+;; Define once
+:my-app/common-kafka-config
+{:bootstrap-server #option KAFKA_BOOTSTRAP_SERVER
+ :auth/strategy    [:strategy/ConfluentCloud
+                    :api-key    #option CONFLUENT_API_KEY
+                    :api-secret #option CONFLUENT_API_SECRET]}
+
+;; Reference in consumers, producers, admin clients
+:my-app/my-producer
+{:bootstrap-server #ref [:my-app/common-kafka-config :bootstrap-server]
+ :strategies       [#ref [:my-app/common-kafka-config :auth/strategy]
+                    [:strategy/EdnSerializer :producer :value]]}
+```
+
+### Auth provider selection with `#config/case`
+
+When supporting multiple auth backends (Confluent Cloud, MSK IAM, MSK SCRAM), `#config/case` selects both the bootstrap server and the auth strategy based on an env variable:
+
+```clojure
+:my-app/common-kafka-config
+{:bootstrap-server #config/case [#or [#option KAFKA_AUTH_PROVIDER "Confluent"]
+                                  "Confluent" #option CONFLUENT_BOOTSTRAP_SERVER
+                                  "MskIam"    #option MSK_IAM_BOOTSTRAP_SERVER
+                                  "MskScram"  #option MSK_SCRAM_BOOTSTRAP_SERVER]
+ :auth/strategy    #config/case [#or [#option KAFKA_AUTH_PROVIDER "Confluent"]
+                                  "Confluent" [:strategy/ConfluentCloud
+                                               :api-key    #option CONFLUENT_API_KEY
+                                               :api-secret #option CONFLUENT_API_SECRET]
+                                  "MskIam"    [:strategy/AwsMskIam]
+                                  "MskScram"  [:strategy/AwsMskScram
+                                               :aws.msk/username #option MSK_SCRAM_USERNAME
+                                               :aws.msk/password #option MSK_SCRAM_PASSWORD]]}
+```
+
+### Two-asserter pattern: config topics vs state topics
+
+In practice, applications use two separate `::ktable-asserter` components because config topics and state topics need different compaction policies:
+
+```clojure
+;; Shared compaction tuning — reference this from both asserters
+:my-app/common-ktable-config
+{:topic-delete-retention-ms        86400000   ;; tombstones kept 24 hours
+ :ktable-segment-ms                43200000   ;; segments max 12 hours
+ :ktable-max-compaction-lag-ms     604800000  ;; compact at least weekly
+ :ktable-min-cleanable-dirty-ratio 0.2}
+
+;; Config ktables: pure "compact" — records are valid forever until replaced
+:my-app/ktable-asserter:config
+{:bootstrap-server              #ref [:my-app/common-kafka-config :bootstrap-server]
+ :strategies                    [#ref [:my-app/common-kafka-config :auth/strategy]]
+ :update-topics-with-bad-config true
+ :topic-name-providers          [#ig/ref :my-app/config-topic-provider]
+ :topic-delete-retention-ms     #ref [:my-app/common-ktable-config :topic-delete-retention-ms]
+ :ktable-segment-ms             #ref [:my-app/common-ktable-config :ktable-segment-ms]
+ :ktable-max-compaction-lag-ms  #ref [:my-app/common-ktable-config :ktable-max-compaction-lag-ms]
+ :ktable-min-cleanable-dirty-ratio #ref [:my-app/common-ktable-config :ktable-min-cleanable-dirty-ratio]}
+ ;; :ktable-compaction-policy defaults to "compact"
+
+;; State ktables: "compact,delete" — records expire after retention period
+:my-app/ktable-asserter:state
+{:bootstrap-server                 #ref [:my-app/common-kafka-config :bootstrap-server]
+ :strategies                       [#ref [:my-app/common-kafka-config :auth/strategy]]
+ :update-topics-with-bad-config    true
+ :increase-existing-partitions?    true
+ :ktable-compaction-policy         "delete,compact"
+ :topic-name-providers             [#ig/ref :my-app/state-topic-a-provider
+                                    #ig/ref :my-app/state-topic-b-provider]
+ :topic-delete-retention-ms        #ref [:my-app/common-ktable-config :topic-delete-retention-ms]
+ ;; ... other compaction refs
+ }
+```
+
+### Producer-consumer pipeline (consume → transform → produce)
+
+Use `ProduceConsumerResultsWithProducer` in the consumer's `:strategies` to wire a producer as the sink. The consumer's `IConsumerClient` returns messages to be produced; the strategy handles the actual `produce!` call:
+
+```clojure
+:my-app/my-producer
+{:bootstrap-server #ref [:my-app/common-kafka-config :bootstrap-server]
+ :strategies       [#ref [:my-app/common-kafka-config :auth/strategy]
+                    [:strategy/EdnSerializer :producer :value]
+                    [:strategy/StringSerializer :producer :key]
+                    [:strategy/ClientId "my-service"]
+                    [:strategy/ProducerCompression "lz4"]
+                    [:strategy/ProducerBatching :linger-ms 500]]}
+
+:my-app/my-consumer
+{:bootstrap-server           #ref [:my-app/common-kafka-config :bootstrap-server]
+ :consumer/client            #ig/ref :my-app/my-consumer-client
+ :service-health-trip-switch #ig/ref :afrolabs.components.health/component
+ :strategies                 [[:strategy/ByteArraySerializer :consumer :both]
+                               [:strategy/SubscribeWithTopicNameProvider
+                                :topic-name-providers [#ig/ref :my-app/source-topics]]
+                               [:strategy/OffsetReset "latest"]
+                               [:strategy/ConsumerGroup "my-consumer-group"]
+                               [:strategy/ClientId "my-service"]
+                               #ref [:my-app/common-kafka-config :auth/strategy]
+                               [:strategy/AutoCommitOffsets :commit-interval-ms 5000]
+                               [:strategy/ReduceRebalanceFrequency
+                                :request-timeout-ms 45000
+                                :heartbeat-interval-ms 15000]
+                               [:strategy/HighThroughput
+                                :consumer-fetch-min-bytes 100000
+                                :consumer-max-poll-records 1000]
+                               [:strategy/ProduceConsumerResultsWithProducer
+                                #ig/ref :my-app/my-producer]]}
+```
+
+### KTable with startup blocking and checkpoint storage
+
+Set `:caught-up-once? true` so the component blocks until it has consumed up to the current end offset before declaring itself ready. Add `:ktable-checkpoint-storage` to resume from a persisted offset instead of replaying from the start:
+
+```clojure
+:my-app/my-ktable
+{:ktable-id                  "my-ktable-id"
+ :caught-up-once?            true
+ :bootstrap-server           #ref [:my-app/common-kafka-config :bootstrap-server]
+ :clock                      #ig/ref :afrolabs.components.time/system-time
+ :strategies                 [#ref [:my-app/common-kafka-config :auth/strategy]
+                               [:strategy/SubscribeWithTopicNameProvider
+                                :topic-name-providers [#ig/ref :my-app/my-topic-provider]]
+                               [:strategy/StringSerializer :consumer :key]
+                               [:strategy/EdnSerializer :consumer :value
+                                :parse-inst-as-java-time true]
+                               [:strategy/HighThroughput
+                                :consumer-fetch-min-bytes 1000000
+                                :consumer-max-poll-records 10000]]
+ :service-health-trip-switch #ig/ref :afrolabs.components.health/component
+ :ktable-checkpoint-storage  #ig/ref :my-app/ktable-checkpoint-store
+ :ktable-asserter            #ig/ref :my-app/ktable-asserter:state}
+```
+
+### Startup ordering via dependency keys
+
+Consumers accept `:wait-for-topics-to-be-asserted` (and some components use `:create-topics-before-using-them`) to ensure topic asserters have run before the consumer starts polling. These keys are not part of the consumer's logic — they exist purely to establish an Integrant init-order dependency:
+
+```clojure
+:my-app/my-consumer
+{;; ... normal consumer config ...
+ :wait-for-topics-to-be-asserted [#ig/ref :my-app/ktable-asserter:state
+                                   #ig/ref :my-app/topic-asserter]}
+```
+
+## Utility Functions
+
+- `->millis-from-epoch x` — converts integer, string (ISO-8601), `Instant`, or `ZonedDateTime` to epoch millis
+- `consumer-end-offsets consumer` — returns current end offsets as a set of `{:topic :partition :offset}` maps
+- `consumer-current-offsets consumer` — returns current consumer position in the same format
+- `consumer:fully-current? consumer timeout timeout-value` — returns current offsets if consumer is fully caught up, else nil
+- `msgs->topic-partition-maxoffsets msgs` — helper to find the max offset per topic-partition from a batch of consumed records

--- a/src/afrolabs/components/kafka.clj
+++ b/src/afrolabs/components/kafka.clj
@@ -2292,8 +2292,8 @@ Returns a subscription handle with which you can unsubscribe later.")
                                       (keep (fn [[topic partition offset]]
                                               (let [ktable-progress-offset (get-in ktable-topic-partition-offsets
                                                                                    [topic partition])]
-                                                (when (and ktable-progress-offset
-                                                           (< ktable-progress-offset offset))
+                                                (when (or (nil? ktable-progress-offset)
+                                                          (< ktable-progress-offset offset))
                                                   :not-caught-up-yet))))
                                       (count)
                                       (zero?)))))]

--- a/src/afrolabs/components/kafka/checkpoint_storage/stores.clj
+++ b/src/afrolabs/components/kafka/checkpoint_storage/stores.clj
@@ -578,9 +578,7 @@ The client is responsible for closing the stream.")
                                                   :key "ktable-checkpoints/lkc-12gm26_location-replay-state/1780278732002-2026-06-01T01:52:12.00228535Z.edn.gz"})]
             (afrolabs.components.kafka.checkpoint-storage/deserialize in))))
 
-  (aws/invoke s3-client
-              {:op :ListObjects
-               :request {:Bucket }})
+
 
 
   )

--- a/src/afrolabs/components/kafka/checkpoint_storage/stores.clj
+++ b/src/afrolabs/components/kafka/checkpoint_storage/stores.clj
@@ -528,6 +528,66 @@ The client is responsible for closing the stream.")
 
     result))
 
+(defn open-s3-download-stream
+  "Returns a `java.io.PipedInputStream` from which the S3 object at `s3-obj-address` can be read.
+
+  NOTE: This method is a reimplementation of the `s3-object->InputStream` fn.
+  It has not been activated into any active codepath yet, pending more efficient encoding than EDN+GZIP
+
+  A background thread fetches the object in range-request chunks and writes each chunk's bytes
+  into the pipe as soon as they arrive, overlapping network I/O with the caller's reads.
+  After writing chunk N to the pipe buffer the background thread immediately issues the S3
+  request for chunk N+1, hiding inter-chunk round-trip latency from the caller.
+
+  It is the caller's responsibility to close the returned stream."
+  [{:keys [s3-client]} s3-obj-address]
+  (let [pipe-out (PipedOutputStream.)
+        pipe-in  (PipedInputStream. pipe-out *chunk-size-bytes*)]
+    (csp/thread
+      (try
+        (doseq [^InputStream chunk-is (get-object-chunks s3-client s3-obj-address)]
+          (.transferTo chunk-is pipe-out))
+        (.close pipe-out)
+        (catch Throwable t
+          (log/error t "Unable to download S3 object chunk.")
+          (.close pipe-out))))
+    pipe-in))
+
+(comment
+
+  (require '[afrolabs.components.aws.sso :as -aws-sso-profile-provider])
+
+  (def s3-client (aws/client {:api :s3
+                              :region "af-south-1"
+                              :credentials-provider (-aws-sso-profile-provider/provider (or (System/getenv "AWS_PROFILE")
+                                                                                            (System/getProperty "aws.profile")
+                                                                                            "default"))}))
+
+  (time (binding [*chunk-size-bytes* 250000
+                  ]
+          (with-open [in (open-s3-download-stream {:s3-client s3-client}
+                                                  {:bucket "ktable-checkpoint-store20250409130905505000000001"
+                                                   :key "ktable-checkpoints/lkc-12gm26_location-replay-state/1780278732002-2026-06-01T01:52:12.00228535Z.edn.gz"})]
+            (afrolabs.components.kafka.checkpoint-storage/deserialize in))))
+
+
+
+  (time (binding [*chunk-size-bytes* 250000]
+          (with-open [in (s3-object->InputStream {:s3-client s3-client}
+                                                 {:bucket "ktable-checkpoint-store20250409130905505000000001"
+                                                  :key "ktable-checkpoints/lkc-12gm26_location-replay-state/1780278732002-2026-06-01T01:52:12.00228535Z.edn.gz"})]
+            (afrolabs.components.kafka.checkpoint-storage/deserialize in))))
+
+  (aws/invoke s3-client
+              {:op :ListObjects
+               :request {:Bucket }})
+
+
+  )
+
+
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- s3:open-checkpoint-output-stream
@@ -576,14 +636,17 @@ The client is responsible for closing the stream.")
              #"/")
 
   (aws/ops s3-client)
-  (aws/invoke s3-client
-              {:op :ListObjectsV2
-               :request {:Bucket "ktable-checkpoint-store20250401120818030200000001"
-                         :Prefix ""}})
+
+  (->>
+   (aws/invoke s3-client
+               {:op :ListObjectsV2
+                :request {:Bucket "ktable-checkpoint-store20250409130905505000000001"
+                          :Prefix ""}})
+   :Contents)
 
   (s3:list-checkpoint-ids {:s3-client      s3-client
-                           :s3:bucketname  "ktable-checkpoint-store20250401120818030200000001"
-                           :s3:path-prefix "test"}
+                           :s3:bucketname  "ktable-checkpoint-store20250409130905505000000001"
+                           :s3:path-prefix "ktable-checkpoints"}
                           "boom-ktable-id")
   (count *1)
 

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -21,7 +21,9 @@
    [com.potetm.fusebox.retry :as retry]
    )
   (:import
-   [java.io File FileOutputStream])
+   [java.io File FileOutputStream]
+   [org.apache.kafka.common TopicPartition]
+   [org.apache.kafka.clients.consumer Consumer OffsetAndMetadata])
   )
 
 ;;;;;;;;;;;;;;;;;;;;
@@ -130,20 +132,26 @@
     :keys [record->event-timestamp-column-name
            parallel-sort?]
     :or   {parallel-sort? false}}
-   state]
-  (doseq [[partition {:keys [dataset topic]}] state]
-    (try (retry/with-retry retryer
-           (with-open [fos (open-parquet-file-data-stream cfg partition)]
-             (let [ds (ds/sort-by-column (dataset)
-                                         (record->event-timestamp-column-name topic)
-                                         nil
-                                         {:parallel? parallel-sort?})]
-               (ds-parquet/ds->parquet ds fos)
-               (log/with-context+ {:partition  partition
-                                   :nr-records (ds/row-count ds)}
-                 (log/info "Saved parquet file.")))))
-         (catch Throwable t
-           (log/error t "Unable to persist parquet files even after retries."))))
+   state
+   commit-ch]
+  (doseq [[topic {:as topic-accumulator :keys [datasets partition-offsets]}] state]
+    (doseq [[data-partition dataset]  datasets]
+      ;; partition {:keys [dataset topic]}
+      (try (retry/with-retry retryer
+             (with-open [fos (open-parquet-file-data-stream cfg data-partition)]
+               (let [ds (ds/sort-by-column (dataset)
+                                           (record->event-timestamp-column-name topic)
+                                           nil
+                                           {:parallel? parallel-sort?})]
+                 (ds-parquet/ds->parquet ds fos)
+                 (log/with-context+ {:partition  data-partition
+                                     :nr-records (ds/row-count ds)}
+                   (log/info "Saved parquet file.")))))
+           (catch Throwable t
+             (log/error t "Unable to persist parquet files even after retries."))))
+    ;; NOTE: This will sync on post-consume-hook or stall
+    ;; FIXME: This commits offsets regardless of success or failure
+    (csp/>!! commit-ch [topic partition-offsets]))
   nil)
 
 (defn- export-any!
@@ -158,13 +166,14 @@
     :keys [clock
            max-file-duration
            max-nr-of-msgs]}
-   state]
+   state
+   commit-ch]
   (let [duration-based-cutof (t/- (-time/get-current-instant clock)
                                   max-file-duration)
-        exportable?          (fn [[_key {:as   _state-item
-                                         :keys [oldest-timestamp
-                                                nr-records]}]]
-                               (or (t/before? oldest-timestamp
+        exportable?          (fn [[_topic {:as   _state-item
+                                           :keys [accumulation-starts
+                                                  nr-records]}]]
+                               (or (t/before? accumulation-starts
                                               duration-based-cutof)
                                    (>= nr-records
                                        max-nr-of-msgs)))
@@ -178,7 +187,7 @@
 
     ;; export what qualified
     (when (seq exportable-state)
-      (export! cfg exportable-state))
+      (export! cfg exportable-state commit-ch))
 
     held-state))
 
@@ -189,21 +198,12 @@
   [{:as   _cfg
     :keys [max-file-duration]}
    state]
-  (cond
-    (not (seq state))
+  (if (not (seq state))
     nil
-
-    (= 1 (count state))
-    (t/+ (-> state first second :oldest-timestamp)
-         max-file-duration)
-
-    :else
-    (let [earliest-timestamp
-          (->> state
-               (map (comp :oldest-timestamp second))
-               (reduce t/min))]
-      (t/+ earliest-timestamp
-           max-file-duration))))
+    (t/+ (->> state
+              (map (comp :accumulation-starts second))
+              (reduce t/min))
+         max-file-duration)))
 
 (defn- ->msg
   "Accepts a message and returns a 2-tuple of
@@ -236,40 +236,45 @@
    state
    msgs]
   (let [right-now (-time/get-current-instant clock)]
-    (reduce (fn [state' {:as msg :keys [topic]}]
+    (reduce (fn [state' {:as msg :keys [topic partition offset]}]
               (let [[dataset-partition row-data] (->msg cfg msg)]
-                (update state'
-                        dataset-partition
-                        (fnil (fn [{:as   partition-state
-                                    :keys [dataset]}]
-
-                                ;; this is a side-effect!
-                                ;; `dataset` is a reader-fn that accepts one record at a time, building up fancy things in the background
-                                (dataset row-data)
-                                (update partition-state :nr-records inc))
-                              {:oldest-timestamp right-now
-                               :topic            topic
-                               :dataset          (ds/mapseq-parser)
-                               :nr-records       0}))))
+                (-> state'
+                    (update-in [topic]
+                               (fnil (fn [topic-state]
+                                       (-> topic-state
+                                           (update :nr-records inc)
+                                           (update-in [:partition-offsets partition] (fnil max 0) offset)))
+                                     {:topic               topic
+                                      :nr-records          0
+                                      :accumulation-starts right-now
+                                      :datasets            {}
+                                      :partition-offsets   {}}))
+                    (update-in [topic :datasets dataset-partition]
+                               (fnil (fn [dataset]
+                                       ;; this is a side-effect!
+                                       ;; `dataset` is a reader-fn that accepts one record at a time,
+                                       ;; building up fancy unboxed-array things in the background
+                                       (dataset row-data) ;; returns nil
+                                       dataset)
+                                     (ds/mapseq-parser))))))
             (or state {})
             msgs)))
-
-(defn- cleanup!
-  "Exports any and all state, flushes into new parquet files regardless of collection duration.
-
-  This should only be used when the consumer is shutting down."
-  [cfg state] (export! cfg state))
 
 ;;;;;;;;;;;;;;;;;;;;
 
 (defn make-msgs-consumer-worker
   [{:as   cfg
     :keys [clock]}
-   incoming-msgs-ch]
+   incoming-msgs-ch
+   commit-ch]
   (csp/thread (loop [state {}]
                 ;; this loop performs the ->parquet export at the start of the loop, if there is anything to do
-                (let [state           (export-any! cfg state) ;; NOTE: shadow-binding
-                      next-to-instant (next-timeout cfg state)
+                (let [;; NOTE: shadow-binding of `state`
+                      state           (export-any! cfg
+                                                   state
+                                                   commit-ch)
+                      next-to-instant (next-timeout cfg
+                                                    state)
                       next-timeout-ch (when next-to-instant
                                         (csp/timeout (.toMillis (t/duration (-time/get-current-instant clock)
                                                                             next-to-instant))))
@@ -283,8 +288,7 @@
                         ;; stop signal
                         (and (= ch incoming-msgs-ch)
                              (nil? v))
-                        (do (log/trace "cleaning up...")
-                            (cleanup! cfg state)
+                        (do (log/trace "fin.")
                             nil)
 
                         ;; we now know we've received messages in v
@@ -379,8 +383,24 @@
                 (update   :max-file-duration (partial apply t/duration))
                 (prepare-storage))
         incoming-msgs-ch (csp/chan 1)
+        commit-ch (csp/chan 1) ;; receives offsets that can be committed
+        post-consume-hook (reify
+                            -kafka/IPostConsumeHook
+                            (post-consume-hook [_ consumer _consumed-records]
+                              (when-let [[topic' partition-offsets] (csp/poll! commit-ch)]
+                                (log/with-context+ {:topic             topic'
+                                                    :partition-offsets partition-offsets}
+                                  (log/trace "Commit offsets for parquet consumer."))
+                                (.commitSync ^Consumer consumer
+                                             (into {}
+                                                   (map (fn [[partition' offset']]
+                                                          [(TopicPartition. topic' (inc (int partition')))
+                                                           (OffsetAndMetadata. offset')]))
+                                                   partition-offsets)))))
+
         consumer-worker (make-msgs-consumer-worker cfg
-                                                   incoming-msgs-ch)
+                                                   incoming-msgs-ch
+                                                   commit-ch)
         consumer-client (reify
                           -kafka/IConsumerClient
                           (consume-messages [_ msgs]
@@ -398,6 +418,8 @@
                                                       (re-pattern topic-regex-str)
                                                       [back-pressure-aware-consumer])
                                                      back-pressure-aware-consumer
+                                                     (-kafka/AutoCommitOffsets :disabled true)
+                                                     post-consume-hook ;; has the job of committing offsets
                                                      ]))))
                 (assoc :consumer/client back-pressure-aware-consumer))
 

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -294,6 +294,7 @@
                         (and (= ch incoming-msgs-ch)
                              (nil? v))
                         (do (log/trace "fin.")
+                            (csp/close! commit-ch)
                             nil)
 
                         ;; we now know we've received messages in v
@@ -389,7 +390,11 @@
                 (prepare-storage))
 
         incoming-msgs-ch (csp/chan 1)
-        commit-ch (csp/chan 1) ;; receives offsets that can be committed
+
+        ;; Receives offsets that can be committed to the consumer.
+        ;; By not specifying chan-size, the put (containing offsets) will block
+        ;; until the poll reads it, synchronizing to the extend that offsets won't be lost during shutdown
+        commit-ch (csp/chan)
         post-consume-hook (reify
                             -kafka/IPostConsumeHook
                             (post-consume-hook [_ consumer _consumed-records]
@@ -438,9 +443,16 @@
 
       -comp/IHaltable
       (halt [_]
-        (-comp/halt consumer)
+        ;; this will start to discard incoming messages
+        ;; and also signal a stop on the export loop
+        ;; giving chance to finish
         (csp/close! incoming-msgs-ch)
-        (csp/<!! consumer-worker)))))
+
+        ;; post-consume-hook will still run through all of this
+        ;; giving a chance to commit the last possible committables in the channel
+        (csp/<!! consumer-worker)
+
+        (-comp/halt consumer)))))
 
 ;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -127,13 +127,17 @@
 (defn- export!
   "Creates parquet file exports from everything in `state`. Returns `nil`."
   [{:as   cfg
-    :keys [record->event-timestamp-column-name]}
+    :keys [record->event-timestamp-column-name
+           parallel-sort?]
+    :or   {parallel-sort? false}}
    state]
   (doseq [[partition {:keys [dataset topic]}] state]
     (try (retry/with-retry retryer
            (with-open [fos (open-parquet-file-data-stream cfg partition)]
              (let [ds (ds/sort-by-column (dataset)
-                                         (record->event-timestamp-column-name topic))]
+                                         (record->event-timestamp-column-name topic)
+                                         nil
+                                         {:parallel? parallel-sort?})]
                (ds-parquet/ds->parquet ds fos)
                (log/with-context+ {:partition  partition
                                    :nr-records (ds/row-count ds)}
@@ -413,6 +417,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;
 
+(s/def ::parallel-sort? boolean?)
 (s/def ::max-nr-of-msgs pos-int?)
 (s/def ::max-file-duration (s/or :duration-spec (s/tuple pos-int? #{:seconds :minutes :hours})
                                  :duration-instance #(instance? java.time.Duration %)))
@@ -450,6 +455,7 @@
                                :opt-un [::fs:store-root
                                         ::s3:bucket-name
                                         ::s3:path-prefix
+                                        ::parallel-sort?
                                         ]))
 
 (-comp/defcomponent {::-comp/ig-kw              ::parquet-sink

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -391,16 +391,16 @@
                             -kafka/IPostConsumeHook
                             (post-consume-hook [_ consumer _consumed-records]
                               (when-let [all-commits (csp/poll! commit-ch)]
-                                (doseq [[topic' partition-offsets] all-commits]
-                                  (log/with-context+ {:topic             topic'
-                                                      :partition-offsets partition-offsets}
-                                    (log/trace "Commit offsets for parquet consumer."))
-                                  (.commitSync ^Consumer consumer
-                                               (into {}
-                                                     (map (fn [[partition' offset']]
-                                                            [(TopicPartition. topic' (int partition'))
-                                                             (OffsetAndMetadata. (inc offset'))]))
-                                                     partition-offsets))))))
+                                (log/with-context+ {:all-commits all-commits}
+                                  (log/trace "Commit offsets for parquet consumer."))
+                                (.commitSync ^Consumer consumer
+                                             (into {}
+                                                   (mapcat (fn [[topic' partition-offsets]]
+                                                             (map (fn [[partition' offset']]
+                                                                    [(TopicPartition. topic' (int partition'))
+                                                                     (OffsetAndMetadata. (inc offset'))])
+                                                                  partition-offsets)))
+                                                   all-commits)))))
 
         consumer-worker (make-msgs-consumer-worker cfg
                                                    incoming-msgs-ch

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -136,24 +136,23 @@
     :or   {parallel-sort? false}}
    state
    commit-ch]
-  (doseq [[topic {:as topic-accumulator :keys [datasets partition-offsets]}] state]
-    (doseq [[data-partition dataset]  datasets]
-      ;; partition {:keys [dataset topic]}
-      (try (retry/with-retry retryer
-             (with-open [fos (open-parquet-file-data-stream cfg data-partition)]
-               (let [ds (ds/sort-by-column (dataset)
-                                           (record->event-timestamp-column-name topic)
-                                           nil
-                                           {:parallel? parallel-sort?})]
-                 (ds-parquet/ds->parquet ds fos)
-                 (log/with-context+ {:partition  data-partition
-                                     :nr-records (ds/row-count ds)}
-                   (log/info "Saved parquet file.")))))
-           (catch Throwable t
-             (log/error t "Unable to persist parquet files even after retries.")))))
+  (doseq [[topic {:as _topic-accumulator :keys [datasets]}] state]
+    (doseq [[data-partition dataset] datasets]
+      ;; Each retry opens a new uniquely-named file so partial/failed writes are not overwritten.
+      ;; Throws on exhaustion — caller must not commit offsets if this propagates.
+      (retry/with-retry retryer
+        (with-open [fos (open-parquet-file-data-stream cfg data-partition)]
+          (let [ds (ds/sort-by-column (dataset)
+                                      (record->event-timestamp-column-name topic)
+                                      nil
+                                      {:parallel? parallel-sort?})]
+            (ds-parquet/ds->parquet ds fos)
+            (log/with-context+ {:partition  data-partition
+                                :nr-records (ds/row-count ds)}
+              (log/info "Saved parquet file.")))))))
 
+  ;; Only reached when ALL files have been saved successfully.
   ;; NOTE: This will sync on post-consume-hook or stall
-  ;; FIXME: This commits offsets regardless of success or failure
   (csp/>!! commit-ch (vec (for [[topic {:keys [partition-offsets]}] state]
                             [topic partition-offsets])))
   nil)
@@ -273,13 +272,20 @@
   [{:as   cfg
     :keys [clock]}
    incoming-msgs-ch
-   commit-ch]
+   commit-ch
+   shutdown-fn]
   (csp/thread (loop [state {}]
                 ;; this loop performs the ->parquet export at the start of the loop, if there is anything to do
                 (let [;; NOTE: shadow-binding of `state`
-                      state           (export-any! cfg
-                                                   state
-                                                   commit-ch)
+                      state           (try
+                                        (export-any! cfg state commit-ch)
+                                        (catch Throwable t
+                                          (log/error t
+                                                     (str "Parquet export failed after all retries. "
+                                                          "Shutting down parquet sink to protect data. "
+                                                          "Offsets will NOT be committed — messages will be replayed on restart."))
+                                          (shutdown-fn)
+                                          nil))
                       next-to-instant (next-timeout cfg
                                                     state)
                       next-timeout-ch (when next-to-instant
@@ -412,9 +418,23 @@
                                                                   partition-offsets)))
                                                    all-commits)))))
 
+        ;; Forward reference: consumer is created after the worker, so we use a volatile.
+        ;; The race is safe — shutdown-fn can only be triggered after messages have been processed,
+        ;; which requires the Kafka consumer to be running, which only starts after vreset! below.
+        consumer-volatile (volatile! nil)
+        consumer-halted?  (atom false)
+        halt-consumer!    (fn []
+                            (when (compare-and-set! consumer-halted? false true)
+                              (when-let [c @consumer-volatile]
+                                (-comp/halt c))))
+        shutdown-fn       (fn []
+                            (csp/close! incoming-msgs-ch)
+                            (halt-consumer!))
+
         consumer-worker (make-msgs-consumer-worker cfg
                                                    incoming-msgs-ch
-                                                   commit-ch)
+                                                   commit-ch
+                                                   shutdown-fn)
         consumer-client (reify
                           -kafka/IConsumerClient
                           (consume-messages [_ msgs]
@@ -439,22 +459,23 @@
 
         consumer (-kafka/make-consumer cfg)]
 
+    (vreset! consumer-volatile consumer)
+
     (reify
       clojure.lang.IDeref
       (deref [_] cfg)
 
       -comp/IHaltable
       (halt [_]
-        ;; this will start to discard incoming messages
-        ;; and also signal a stop on the export loop
-        ;; giving chance to finish
+        ;; Closes incoming channel, signalling the worker to stop.
+        ;; Idempotent — shutdown-fn may have already closed it.
         (csp/close! incoming-msgs-ch)
 
         ;; post-consume-hook will still run through all of this
         ;; giving a chance to commit the last possible committables in the channel
         (csp/<!! consumer-worker)
 
-        (-comp/halt consumer)))))
+        (halt-consumer!)))))
 
 ;;;;;;;;;;;;;;;;;;;;
 

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -373,8 +373,6 @@
                   (throw (ex-info "When the parquet sink is used with filesystem, an :fs:store-root is required."
                                   {:provided fs:store-root}))))
 
-  (tap> [:parquet-cfg cfg])
-
   (let [cfg (-> cfg
                 (resolve* :record->event-timestamp-column-name)
                 (resolve* :record->row:fn)

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -148,10 +148,12 @@
                                      :nr-records (ds/row-count ds)}
                    (log/info "Saved parquet file.")))))
            (catch Throwable t
-             (log/error t "Unable to persist parquet files even after retries."))))
-    ;; NOTE: This will sync on post-consume-hook or stall
-    ;; FIXME: This commits offsets regardless of success or failure
-    (csp/>!! commit-ch [topic partition-offsets]))
+             (log/error t "Unable to persist parquet files even after retries.")))))
+
+  ;; NOTE: This will sync on post-consume-hook or stall
+  ;; FIXME: This commits offsets regardless of success or failure
+  (csp/>!! commit-ch (vec (for [[topic {:keys [partition-offsets]}] state]
+                            [topic partition-offsets])))
   nil)
 
 (defn- export-any!
@@ -382,21 +384,23 @@
                 (resolve* :record->row:fn)
                 (update   :max-file-duration (partial apply t/duration))
                 (prepare-storage))
+
         incoming-msgs-ch (csp/chan 1)
         commit-ch (csp/chan 1) ;; receives offsets that can be committed
         post-consume-hook (reify
                             -kafka/IPostConsumeHook
                             (post-consume-hook [_ consumer _consumed-records]
-                              (when-let [[topic' partition-offsets] (csp/poll! commit-ch)]
-                                (log/with-context+ {:topic             topic'
-                                                    :partition-offsets partition-offsets}
-                                  (log/trace "Commit offsets for parquet consumer."))
-                                (.commitSync ^Consumer consumer
-                                             (into {}
-                                                   (map (fn [[partition' offset']]
-                                                          [(TopicPartition. topic' (inc (int partition')))
-                                                           (OffsetAndMetadata. offset')]))
-                                                   partition-offsets)))))
+                              (when-let [all-commits (csp/poll! commit-ch)]
+                                (doseq [[topic' partition-offsets] all-commits]
+                                  (log/with-context+ {:topic             topic'
+                                                      :partition-offsets partition-offsets}
+                                    (log/trace "Commit offsets for parquet consumer."))
+                                  (.commitSync ^Consumer consumer
+                                               (into {}
+                                                     (map (fn [[partition' offset']]
+                                                            [(TopicPartition. topic' (int partition'))
+                                                             (OffsetAndMetadata. (inc offset'))]))
+                                                     partition-offsets))))))
 
         consumer-worker (make-msgs-consumer-worker cfg
                                                    incoming-msgs-ch

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -239,26 +239,29 @@
    msgs]
   (let [right-now (-time/get-current-instant clock)]
     (reduce (fn [state' {:as msg :keys [topic partition offset]}]
-              (let [[dataset-partition row-data] (->msg cfg msg)]
-                (-> state'
-                    (update-in [topic]
-                               (fnil (fn [topic-state]
-                                       (-> topic-state
-                                           (update :nr-records inc)
-                                           (update-in [:partition-offsets partition] (fnil max 0) offset)))
-                                     {:topic               topic
-                                      :nr-records          0
-                                      :accumulation-starts right-now
-                                      :datasets            {}
-                                      :partition-offsets   {}}))
-                    (update-in [topic :datasets dataset-partition]
-                               (fnil (fn [dataset]
-                                       ;; this is a side-effect!
-                                       ;; `dataset` is a reader-fn that accepts one record at a time,
-                                       ;; building up fancy unboxed-array things in the background
-                                       (dataset row-data) ;; returns nil
-                                       dataset)
-                                     (ds/mapseq-parser))))))
+              ;; (->msg ...) may return nil if the record is misformed
+              (or (when-let [[dataset-partition row-data] (->msg cfg msg)]
+                    (-> state'
+                        (update-in [topic]
+                                   (fnil (fn [topic-state]
+                                           (-> topic-state
+                                               (update :nr-records inc)
+                                               (update-in [:partition-offsets partition] (fnil max 0) offset)))
+                                         {:topic               topic
+                                          :nr-records          0
+                                          :accumulation-starts right-now
+                                          :datasets            {}
+                                          :partition-offsets   {}}))
+                        (update-in [topic :datasets dataset-partition]
+                                   (fnil (fn [dataset]
+                                           ;; this is a side-effect!
+                                           ;; `dataset` is a reader-fn that accepts one record at a time,
+                                           ;; building up fancy unboxed-array things in the background
+                                           (dataset row-data) ;; returns nil
+                                           dataset)
+                                         (ds/mapseq-parser)))))
+                  ;; if the msg is misformed, we keep the current state and continue
+                  state'))
             (or state {})
             msgs)))
 

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -117,14 +117,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;
 
-(def max-export-retries 5)
+(def max-export-retries 12)
 
-;; "simple" retrier with exponential backoff
-(def retryer (retry/init {::retry/retry? (fn [n ms ex]
+;; Exponential backoff with jitter, capped at 30 s. 12 attempts gives ~5 min total worst-case,
+;; enough to outlast S3 throttle (503 SlowDown) events.
+(def retryer (retry/init {::retry/retry? (fn [n _ms _ex]
                                            (< n max-export-retries))
-                          ::retry/delay (fn [n ms ex]
-                                          (min (retry/delay-exp 500 n)
-                                               10000))}))
+                          ::retry/delay  (fn [n _ms _ex]
+                                           (retry/jitter 0.2
+                                                         (min (retry/delay-exp 500 n)
+                                                              30000)))}))
 
 (defn- export!
   "Creates parquet file exports from everything in `state`. Returns `nil`."

--- a/src/afrolabs/components/kafka/sinks/parquet.clj
+++ b/src/afrolabs/components/kafka/sinks/parquet.clj
@@ -9,9 +9,11 @@
    [afrolabs.components.kafka.back-pressure-aware-consumer :as -bpac]
    [afrolabs.components.kafka.checkpoint-storage.stores :as -checkpoint-stores]
    [afrolabs.components.time :as -time]
+   [afrolabs.prometheus :as -prom]
    [clojure.core.async :as csp]
    [clojure.spec.alpha :as s]
    [cognitect.aws.client.api :as aws]
+   [iapetos.core :as prom]
    [integrant.core :as ig]
    [java-time.api :as t]
    [net.cgrand.xforms :as x]
@@ -46,6 +48,39 @@
 
                (t/zoned-date-time? i)
                (t/with-zone-same-instant i zone-id)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(-prom/register-metric (prom/counter ::records-exported
+                                     {:description "Records successfully written to parquet files."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/counter ::parquet-files-written
+                                     {:description "Parquet files successfully written to storage."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/counter ::records-dropped
+                                     {:description "Records dropped due to ->msg conversion failure."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/gauge ::datasets-in-progress
+                                   {:description "Datasets currently accumulating in the parquet sink."}))
+(-prom/register-metric (prom/gauge ::records-in-progress
+                                   {:description "Records in all in-progress datasets in the parquet sink."}))
+(-prom/register-metric (prom/counter ::export-retries
+                                     {:description "Parquet export attempts that failed and triggered a retry."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/counter ::export-critical-failure
+                                     {:description "CRITICAL: parquet export exhausted all retries; sink is shutting down."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/summary ::export-write-duration-secs
+                                     {:description "Time taken to write one parquet file to storage (excludes sorting)."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/summary ::export-sort-duration-secs
+                                     {:description "Time taken to sort a dataset by event timestamp before export."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/summary ::accumulation-age-secs
+                                     {:description "How long a dataset accumulated before being flushed to parquet."
+                                      :labels      [:topic]}))
+(-prom/register-metric (prom/summary ::incoming-batch-size
+                                     {:description "Number of messages per batch delivered to the parquet sink collector."}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -141,15 +176,24 @@
       ;; Each retry opens a new uniquely-named file so partial/failed writes are not overwritten.
       ;; Throws on exhaustion — caller must not commit offsets if this propagates.
       (retry/with-retry retryer
-        (with-open [fos (open-parquet-file-data-stream cfg data-partition)]
-          (let [ds (ds/sort-by-column (dataset)
-                                      (record->event-timestamp-column-name topic)
-                                      nil
-                                      {:parallel? parallel-sort?})]
-            (ds-parquet/ds->parquet ds fos)
-            (log/with-context+ {:partition  data-partition
-                                :nr-records (ds/row-count ds)}
-              (log/info "Saved parquet file.")))))))
+        (try
+          (with-open [fos (open-parquet-file-data-stream cfg data-partition)]
+            (let [ds        (prom/with-duration (get-summary-export-sort-duration-secs {:topic topic})
+                              (ds/sort-by-column (dataset)
+                                                 (record->event-timestamp-column-name topic)
+                                                 nil
+                                                 {:parallel? parallel-sort?}))
+                  row-count (ds/row-count ds)]
+              (prom/with-duration (get-summary-export-write-duration-secs {:topic topic})
+                (ds-parquet/ds->parquet ds fos))
+              (prom/inc (get-counter-records-exported {:topic topic}) row-count)
+              (prom/inc (get-counter-parquet-files-written {:topic topic}))
+              (log/with-context+ {:partition  data-partition
+                                  :nr-records row-count}
+                (log/info "Saved parquet file."))))
+          (catch Throwable t
+            (prom/inc (get-counter-export-retries {:topic topic}))
+            (throw t))))))
 
   ;; Only reached when ALL files have been saved successfully.
   ;; NOTE: This will sync on post-consume-hook or stall
@@ -190,6 +234,10 @@
 
     ;; export what qualified
     (when (seq exportable-state)
+      (let [now (-time/get-current-instant clock)]
+        (doseq [[topic {:keys [accumulation-starts]}] exportable-state]
+          (prom/observe (get-summary-accumulation-age-secs {:topic topic})
+                        (/ (.toMillis (t/duration accumulation-starts now)) 1000.0))))
       (export! cfg exportable-state commit-ch))
 
     held-state))
@@ -229,6 +277,7 @@
        (catch Throwable t
          (log/with-context+ (select-keys kafka-msg [:topic :partition :offset])
            (log/error t "->msg failed to work for a message."))
+         (prom/inc (get-counter-records-dropped {:topic topic}))
          nil ;; be explicit
          )))
 
@@ -238,6 +287,7 @@
     :keys [clock]}
    state
    msgs]
+  (prom/observe (get-summary-incoming-batch-size) (count msgs))
   (let [right-now (-time/get-current-instant clock)]
     (reduce (fn [state' {:as msg :keys [topic partition offset]}]
               ;; (->msg ...) may return nil if the record is misformed
@@ -266,6 +316,12 @@
             (or state {})
             msgs)))
 
+(defn- update-in-progress-metrics! [state]
+  (prom/observe (get-gauge-datasets-in-progress)
+                (transduce (map (comp count :datasets second)) + 0 state))
+  (prom/observe (get-gauge-records-in-progress)
+                (transduce (map (comp :nr-records second)) + 0 state)))
+
 ;;;;;;;;;;;;;;;;;;;;
 
 (defn make-msgs-consumer-worker
@@ -284,6 +340,8 @@
                                                      (str "Parquet export failed after all retries. "
                                                           "Shutting down parquet sink to protect data. "
                                                           "Offsets will NOT be committed — messages will be replayed on restart."))
+                                          (doseq [topic (keys state)]
+                                            (prom/inc (get-counter-export-critical-failure {:topic topic})))
                                           (shutdown-fn)
                                           nil))
                       next-to-instant (next-timeout cfg
@@ -320,6 +378,7 @@
                         (do (log/trace "timed out")
                             state))]
                   (when next-state
+                    (update-in-progress-metrics! next-state)
                     (recur next-state))))
               (log/info "Parquet sink worker thread stopped.")))
 

--- a/src/afrolabs/components/kafka/utilities.clj
+++ b/src/afrolabs/components/kafka/utilities.clj
@@ -99,7 +99,7 @@
         caught-up-ch (csp/chan)
         _ (csp/go (csp/<! caught-up-ch)
                   (csp/close! caught-up-ch) ;; prevents publishers from blocking
-                  (info "Caught up to the end of the subscribed topics, closing...")
+                  (info "CaughtUpNotifications fired: consumer reached end of all partitions, stopping...")
                   (deliver loaded-enough-msgs true))
 
         health-trip-switch (-healthcheck/make-fake-health-trip-switch loaded-enough-msgs)
@@ -125,18 +125,26 @@
 
                                                  ;; we want to throw if no clause matches
                                                  )))
+                  raw-count (count msgs)
                   msgs (filter (fn [msg]
                                  (and (msg-filter msg)
                                       (from-to-timestamp-filter msg)))
                                msgs)
+                  filtered-count (count msgs)
+
+                  _ (log/trace "consume-messages batch"
+                               {:raw-count      raw-count
+                                :filtered-count filtered-count
+                                :has-stream-ch  (some? stream-ch)})
 
                   _ (when collect-messages?
                       (swap! loaded-msgs conj! msgs))
-                  how-many (swap! running-total + (count msgs))]
+                  how-many (swap! running-total + filtered-count)]
 
               ;; is streaming defined? if so, send it on
               (when stream-ch
                 (when-not (csp/>!! stream-ch msgs)
+                  (info "stream-ch closed by consumer, stopping...")
                   (deliver loaded-enough-msgs true)))
 
               ;; do we have enough yet? is anything ever enough?
@@ -183,7 +191,6 @@
                                                                ;; what is the ultimate max offset per topic-partition
                                                                partition-highest-offsets (.endOffsets ^Consumer consumer
                                                                                                       partition-assignment)
-                                                               #_#__ (tap> [:partition-highest-offsets partition-highest-offsets])
 
                                                                ;; what is the offset for the to-timestamp value
                                                                offsets-for-times (into {}
@@ -191,7 +198,6 @@
                                                                                                          (into {}
                                                                                                                (map #(vector % to-timestamp-ms))
                                                                                                                partition-assignment)))
-                                                               #_#__ (tap> [:offsets-for-times offsets-for-times])
 
                                                                ;; where are the offsets, where we must consume from?
                                                                relevant-offsets (->> (for [[^TopicPartition tp highest-offset] partition-highest-offsets
@@ -200,47 +206,56 @@
                                                                                                        (get tp)
                                                                                                        (.offset))
                                                                                                highest-offset)])
-                                                                                     (into {}))
-                                                               #_#__ (tap> [:relevant-offsets relevant-offsets])]
-                                                           (log/spy :trace "remaining"
-                                                                    (reset! remaining-topic-partitions
-                                                                            (set (keys relevant-offsets))))
-                                                           (log/spy :trace "topic-partitinos-end-offests"
-                                                                    (reset! topic-partition-end-offsets
-                                                                            relevant-offsets))))
+                                                                                     (into {}))]
+
+                                                           (reset! remaining-topic-partitions (set (keys relevant-offsets)))
+                                                           (reset! topic-partition-end-offsets relevant-offsets)
+
+                                                           (log/trace "to-timestamp strategy: initialized"
+                                                                      {:to-timestamp-ms          to-timestamp-ms
+                                                                       :partition-count           (count partition-assignment)
+                                                                       :tracked-partition-count   (count relevant-offsets)
+                                                                       :partitions-with-ts-offset (->> offsets-for-times
+                                                                                                       (keep (fn [[tp o]] (when o (.toString tp))))
+                                                                                                       count)
+                                                                       :partitions-using-end-offset (->> offsets-for-times
+                                                                                                         (keep (fn [[tp o]] (when-not o (.toString tp))))
+                                                                                                         count)})))
 
 
                                                        ;; now we inspect the consumed-records and pause partitions
                                                        ;; where we see offsets higher than what is in topic-partition-end-offsets
-                                                       (let [;; (k/msgs->topic-partition-maxoffsets consumed-records)
-                                                             ;; _ (tap> [:max-offsets-per-topic-partition max-offsets-per-topic-partition])
-                                                             overrun-topic-partitions (->> @remaining-topic-partitions
-                                                                                           (map (fn [tp] [tp (.position ^Consumer consumer tp)]))
+                                                       (let [partition-positions (into {}
+                                                                                       (map (fn [tp] [tp (.position ^Consumer consumer tp)]))
+                                                                                       @remaining-topic-partitions)
+
+                                                             overrun-topic-partitions (->> partition-positions
                                                                                            (filter (fn [[topic-partition position]]
-                                                                                                     (log/trace [:position                     position
-                                                                                                                 :topic-partition              topic-partition
-                                                                                                                 :topic-partitions-and-offsets @topic-partition-end-offsets
-                                                                                                                 :max-topic-partition          (get @topic-partition-end-offsets
-                                                                                                                                                    topic-partition)])
                                                                                                      (if-let [test-offset (get @topic-partition-end-offsets topic-partition)]
                                                                                                        (<= test-offset position)
                                                                                                        true ;; if we don't have a fixed dest-offset, and neither a valid end-offset, it means this topic has no data and we should stop consuming from it
                                                                                                        )))
                                                                                            (mapv first))]
 
+                                                         (log/trace "to-timestamp strategy: poll"
+                                                                    {:remaining-count (count @remaining-topic-partitions)
+                                                                     :overrun-count   (count overrun-topic-partitions)})
+
                                                          ;; pause the partition that has overrun
                                                          ;; AND remove it from the list of partitions we are consuming from (assignment)
                                                          (when (seq overrun-topic-partitions)
-                                                           (log/debug (str "Pausing " overrun-topic-partitions))
+                                                           (log/debug "to-timestamp strategy: pausing overrun partitions"
+                                                                      {:pausing overrun-topic-partitions})
                                                            (.pause ^Consumer consumer overrun-topic-partitions)
-                                                           (log/debug [:remaining
-                                                                       (swap! remaining-topic-partitions
-                                                                              (fn [remaining]
-                                                                                (set/difference remaining
-                                                                                                (set overrun-topic-partitions))))]))
+                                                           (let [remaining (swap! remaining-topic-partitions
+                                                                                  set/difference
+                                                                                  (set overrun-topic-partitions))]
+                                                             (log/trace "to-timestamp strategy: updated remaining"
+                                                                        {:remaining-count (count remaining)})))
 
                                                          ;; when we're no longer remaining with any partitions, stop the consumer
                                                          (when-not (seq @remaining-topic-partitions)
+                                                           (log/info "to-timestamp strategy: all partitions consumed to to-timestamp, stopping")
                                                            (deliver loaded-enough-msgs true)))))))])
                                         extra-strategies)]
           {::k/kafka-consumer

--- a/src/afrolabs/components/kafka/utilities/CLAUDE.md
+++ b/src/afrolabs/components/kafka/utilities/CLAUDE.md
@@ -1,0 +1,129 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+The Kafka utilities (`afrolabs.components.kafka.utilities` and its sub-namespaces) are a collection of functions intended primarily for **interactive/REPL use** and **ad-hoc integrant systems**. They wrap the lower-level Kafka component primitives into convenient, self-contained operations.
+
+## Structure
+
+- `utilities.clj` — the main public API; all top-level functions here
+- `utilities/healthcheck.clj` — `make-fake-health-trip-switch`: creates a minimal `IServiceHealthTripSwitch` backed by a promise, for use in ad-hoc integrant systems that need to signal "done" rather than "unhealthy"
+- `utilities/topic_forwarder.clj` — `create-system-config`: builds an integrant system config for forwarding messages between two Kafka clusters; used internally by `forward-topics-between-clusters-2`
+
+## Functions
+
+**Reading data**
+- `load-messages-from-confluent-topic` — Consumes from one or more topics until caught up to current offsets. Supports `:nr-msgs` limit, `:msg-filter`, time-range filtering via `:from-timestamp`/`:to-timestamp`, and streaming via `:stream-ch`. Returns a vector of messages (or nil if `collect-messages?` is false).
+- `load-ktable` — Starts a KTable component and returns an `IDeref`+`IHaltable`. Deref to get current state; halt to stop.
+
+**Inspecting clusters**
+- `list-all-topics` — Returns a set of topic name strings.
+- `describe-topics` — Returns partition/leader/replica info for given topics.
+- `describe-consumer-groups` — Returns consumer group membership and state.
+- `describe-acls` — Returns ACL bindings from the cluster.
+
+**Mutating clusters**
+- `assert-topics` — Ensures topics exist with the given partition count (creates if missing).
+- `alter-topic-config` — Increases partition count for a topic.
+- `delete-some-topics-on-cluster!` — Deletes topics matching a predicate. Never deletes internal topics (those starting with `_`). Supports `:dry-run?`.
+- `delete-all-topics-on-cluster!` — Convenience wrapper over `delete-some-topics-on-cluster!` with `(constantly true)`.
+
+**Producing**
+- `produce-and-wait!` — Produces a batch of messages and blocks until all delivery acks are received.
+
+**Forwarding between clusters**
+- `forward-topics-between-clusters` — REPL-use version. Takes `src-cluster-cfg` and `dest-cluster-cfg` maps and returns an `IHaltable`.
+- `forward-topics-between-clusters-2` — Component-friendly version; accepts an optional `:health-component` to integrate with an existing health trip-switch. Logs forwarding throughput every 30 seconds.
+- `copy-topic` — Copies all data from one topic to another on the same cluster (byte-level copy, preserves key/value only). Blocks until caught up.
+
+## Common Parameter Patterns
+
+Most functions accept a `:bootstrap-server` string and optionally `:confluent-api-key`/`:confluent-api-secret` (both must be non-nil to activate the `ConfluentCloud` strategy). Additional strategies can be injected via `:extra-strategies`.
+
+Config is typically loaded with `(afrolabs.config/load-config ".env-prod")` and destructured as `{:keys [kafka-bootstrap-server confluent-api-key confluent-api-secret]}`.
+
+The `src-cluster-cfg` / `dest-cluster-cfg` maps used by the forwarding functions are plain maps with `:bootstrap-server` and `:strategies`, matching the spec in `topic_forwarder.clj`.
+
+### Serialization strategies
+
+Strategies are passed as vectors in `:extra-strategies`. Common combinations:
+
+```clojure
+;; JSON values, string keys
+[[:strategy/JsonSerializer :consumer :value]
+ [:strategy/StringSerializer :consumer :key]]
+
+;; Raw bytes for both (useful when value needs manual decoding, e.g. gzipped)
+[[:strategy/ByteArraySerializer :consumer :both]]
+
+;; JSON values, raw bytes for key
+[[:strategy/JsonSerializer :consumer :value]
+ [:strategy/ByteArraySerializer :consumer :key]]
+```
+
+## Usage Examples
+
+### Collect all messages from a topic
+
+```clojure
+(def records
+  (-kafka-utils/load-messages-from-confluent-topic
+    :bootstrap-server  kafka-bootstrap-server
+    :api-key           confluent-api-key
+    :api-secret        confluent-api-secret
+    :topics            ["my-topic"]
+    :extra-strategies  [[:strategy/JsonSerializer :consumer :value]
+                        [:strategy/StringSerializer :consumer :key]]
+    :collect-messages? true
+    :from-timestamp    (t/- (t/instant) (t/days 1))
+    :to-timestamp      (t/instant)))
+```
+
+### Stream messages into an accumulator (avoid holding all data in memory)
+
+Use `:collect-messages? false` with `:stream-ch`. The channel receives batches (vectors) of messages and is closed when consumption is complete. Process on a separate `csp/thread` and block on its result:
+
+```clojure
+(let [stream-ch   (csp/chan)
+      accumulator (csp/thread
+                    (loop [result (transient {})]
+                      (if-let [msgs (csp/<!! stream-ch)]
+                        (recur (reduce (fn [acc msg]
+                                         (assoc! acc (get (:value msg) "vehicleId") msg))
+                                       result msgs))
+                        (persistent! result))))]
+  (-kafka-utils/load-messages-from-confluent-topic
+    :bootstrap-server  kafka-bootstrap-server
+    :api-key           confluent-api-key
+    :api-secret        confluent-api-secret
+    :topics            ["my-topic"]
+    :extra-strategies  [[:strategy/JsonSerializer :consumer :value]
+                        [:strategy/StringSerializer :consumer :key]]
+    :collect-messages? false
+    :stream-ch         stream-ch
+    :from-timestamp    start-instant
+    :to-timestamp      to-instant)
+  (csp/<!! accumulator))  ;; block until thread finishes, returns result
+```
+
+The `:value-converter-fn` passed to higher-level helpers like `topic->last-by-vehicle-id` must return a **sequence** of records (not a single record), because `mapcat` is applied to its results. For topics where each Kafka message contains multiple logical records, expand them here:
+
+```clojure
+:value-converter-fn (fn [msg]
+                      (mapcat #(get % "deviceList")
+                              (-> (String. ^bytes (:value msg))
+                                  json/read-str
+                                  json/read-str)))
+```
+
+For topics where each message is a single record, wrap in a vector or use `:value` as a shorthand:
+
+```clojure
+:value-converter-fn :value   ;; returns the :value field directly (treated as a single-element seq)
+```
+
+## Ad-hoc Integrant Systems
+
+Several functions here spin up their own inline `ig/init` / `ig/halt!` systems rather than relying on an outer integrant context. They use `make-fake-health-trip-switch` (from `utilities.healthcheck`) to drive shutdown: a `promise` is delivered when consumption is complete, which triggers `ig/halt!`.

--- a/src/afrolabs/components/kafka/utilities/CLAUDE.md
+++ b/src/afrolabs/components/kafka/utilities/CLAUDE.md
@@ -127,3 +127,20 @@ For topics where each message is a single record, wrap in a vector or use `:valu
 ## Ad-hoc Integrant Systems
 
 Several functions here spin up their own inline `ig/init` / `ig/halt!` systems rather than relying on an outer integrant context. They use `make-fake-health-trip-switch` (from `utilities.healthcheck`) to drive shutdown: a `promise` is delivered when consumption is complete, which triggers `ig/halt!`.
+
+## Timbre logging macros: never embed side effects
+
+Timbre's `log/debug`, `log/trace`, etc. are **macros** that skip argument evaluation entirely when the active log level is above the macro's level. This means any side-effectful expression (e.g. `swap!`, `reset!`, `deliver`) nested inside a log call is silently a no-op in production.
+
+```clojure
+;; WRONG — swap! is never called at :info log level
+(log/debug [:remaining (swap! my-atom f)])
+
+;; CORRECT — always execute the side effect, then log the result
+(let [result (swap! my-atom f)]
+  (log/debug [:remaining result]))
+```
+
+`log/spy` is the one exception: it **always** evaluates its form regardless of level, and only conditionally emits the log line. It is safe to use for side effects, though it's cleaner to keep side effects explicit.
+
+This bug caused `load-messages-from-confluent-topic` with `:to-timestamp` to hang indefinitely in production (`:info` level) because the atom tracking remaining partitions was never updated.

--- a/src/afrolabs/logging.clj
+++ b/src/afrolabs/logging.clj
@@ -83,3 +83,57 @@
   []
   (timbre/merge-config! {:appenders
                          {:println (context-println-appender :colorized-output? true)}}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; in-memory log tap
+;;
+;; A single global ring buffer appender. Install it once; read from anywhere.
+;; nil = not installed.
+
+(defonce ^:private tap-state (atom nil))
+
+(defn- log-tap-appender-fn
+  [{:keys [output_ level ?ns-str ?file ?line ?err context]}]
+  (let [entry {:output  (force output_)
+               :level   level
+               :ns      ?ns-str
+               :file    ?file
+               :line    ?line
+               :context context
+               :error   ?err}]
+    (swap! tap-state
+           (fn [{:keys [mode n buffer] :as state}]
+             (when state
+               (let [buf' (conj buffer entry)]
+                 (assoc state :buffer
+                        (if (and (= mode :most-recent-n) (> (count buf') n))
+                          (subvec buf' 1)
+                          buf'))))))))
+
+(defn install-log-tap!
+  "Install a global in-memory log buffer appender. Idempotent — calling again
+  when already installed is a no-op.
+
+  mode:
+    :most-recent-n  (default) retain only the last `n` log entries (ring buffer)
+    :all            retain every entry (unbounded — use with care)"
+  ([] (install-log-tap! :most-recent-n 100))
+  ([mode] (install-log-tap! mode 100))
+  ([mode n]
+   (when (compare-and-set! tap-state nil {:mode mode :n n :buffer []})
+     (timbre/merge-config!
+      {:appenders {::log-tap {:enabled? true
+                              :async?   false
+                              :fn       log-tap-appender-fn}}}))))
+
+(defn log-tap-entries
+  "Return the current contents of the in-memory log buffer, oldest first.
+  Returns nil if the tap has not been installed."
+  []
+  (:buffer @tap-state))
+
+(defn uninstall-log-tap!
+  "Remove the in-memory log buffer appender and discard buffered entries."
+  []
+  (reset! tap-state nil)
+  (timbre/merge-config! {:appenders {::log-tap nil}}))

--- a/src/dev/test_ds.clj
+++ b/src/dev/test_ds.clj
@@ -1,0 +1,146 @@
+(ns dev.test-ds
+  "Benchmark namespace to verify that the :parallel? flag on sort-by-column
+  actually changes behaviour, and to measure the cost of mapseq-parser
+  materialisation vs sort in the parquet sink's export! path."
+  (:require
+   [clojure.spec.alpha     :as s]
+   [clojure.spec.gen.alpha :as gen]
+   [tech.v3.dataset        :as ds]
+   [tech.v3.libs.parquet   :as _ds-parquet])  ; side-effect: registers :parquet read/write
+  (:import
+   [java.time Instant]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Spec
+
+(def ^:private epoch-2020 (.toEpochMilli (Instant/parse "2020-01-01T00:00:00Z")))
+(def ^:private epoch-2026 (.toEpochMilli (Instant/parse "2026-01-01T00:00:00Z")))
+
+(s/def ::id
+  pos-int?)
+
+(s/def ::value-a
+  (s/double-in :NaN? false :infinite? false :min -1.0e9 :max 1.0e9))
+
+(s/def ::value-b
+  (s/double-in :NaN? false :infinite? false :min -1.0e9 :max 1.0e9))
+
+(s/def ::count-x
+  (s/with-gen int?
+              #(gen/large-integer* {:min -100000 :max 100000})))
+
+(s/def ::label
+  (s/with-gen (s/and string? #(<= (count %) 20))
+              #(gen/fmap (fn [s] (subs s 0 (min 20 (count s))))
+                         (gen/string-alphanumeric))))
+
+(s/def ::category
+  (s/with-gen (s/and string? #(<= (count %) 10))
+              #(gen/fmap (fn [s] (subs s 0 (min 10 (count s))))
+                         (gen/string-alphanumeric))))
+
+(s/def ::timestamp
+  (s/with-gen #(instance? Instant %)
+              #(gen/fmap (fn [^long ms] (Instant/ofEpochMilli ms))
+                         (gen/large-integer* {:min epoch-2020 :max epoch-2026}))))
+
+(s/def ::record
+  (s/keys :req-un [::id
+                   ::value-a
+                   ::value-b
+                   ::count-x
+                   ::label
+                   ::category
+                   ::timestamp]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data generation
+
+(defn generate-seed
+  "Generate a seed batch of n spec-valid records. Expensive — call once."
+  [n]
+  (vec (gen/sample (s/gen ::record) n)))
+
+(defn records-from-seed
+  "Return n records by cycling through seed. Fast — use for large n."
+  [seed n]
+  (vec (take n (cycle seed))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Instrumentation helpers
+
+(defmacro timed
+  "Evaluates body, returns {:result _ :elapsed-ms _}."
+  [& body]
+  `(let [start#  (System/nanoTime)
+         result# (do ~@body)]
+     {:result     result#
+      :elapsed-ms (/ (double (- (System/nanoTime) start#)) 1.0e6)}))
+
+(defn bench
+  "Run thunk, print label and elapsed time, return result."
+  [label thunk]
+  (let [{:keys [result elapsed-ms]} (timed (thunk))]
+    (println (format "%-50s  %8.1f ms" label elapsed-ms))
+    result))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; The two operations under test, mirroring export! in parquet.clj
+
+(defn bench-materialise
+  "Feed records into a fresh mapseq-parser, then time the (parser) call.
+  Returns the materialised dataset."
+  [records]
+  (let [parser (ds/mapseq-parser)]
+    (run! parser records)
+    (bench (format "(dataset) — %d records" (count records)) parser)))
+
+(defn bench-sort
+  "Time sort-by-column on ds with both :parallel? false and :parallel? true.
+  Runs each twice so the JIT gets a chance to settle."
+  [ds colname]
+  (let [n (ds/row-count ds)]
+    (doseq [run [1 2]]
+      (doseq [[label opts] [["serial  :parallel? false" {:parallel? false}]
+                            ["parallel :parallel? true " {:parallel? true}]]]
+        (bench (format "sort-by-column %-28s run %d  n=%d" label run n)
+               #(ds/sort-by-column ds colname nil opts)))))
+  nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(comment
+
+  ;; ── 1. Generate data ─────────────────────────────────────────────────────
+  ;; Generate seed once (slow), then tile it cheaply to get a large dataset.
+  (def seed (generate-seed 2000))
+  (count seed)
+
+  (def records-100k  (records-from-seed seed 100000))
+  (def records-500k  (records-from-seed seed 500000))
+  (def records-5M  (records-from-seed seed 5000000))
+  (def records-50M  (records-from-seed seed 50000000))
+
+  ;; ── 2. Benchmark materialisation ─────────────────────────────────────────
+  ;; This mirrors the (dataset) call in export!
+  (def ds-100k  (bench-materialise records-100k))
+  (def ds-500k  (bench-materialise records-500k))
+  (def ds-5M    (bench-materialise records-5M))
+  (def ds-50M   (bench-materialise records-50M))
+
+  ;; Sanity-check the dataset
+  (ds/row-count ds-100k)
+  (ds/column-names ds-100k)
+  (ds/head ds-100k 3)
+
+  ;; ── 3. Benchmark sort — the fix under test ────────────────────────────────
+  ;; Expect serial ≈ parallel on single-core machines;
+  ;; on multi-core, parallel should be faster for large n,
+  ;; at the cost of maxing out all CPUs during the sort.
+  (bench-sort ds-100k  :timestamp)
+  (bench-sort ds-500k  :timestamp)
+  (bench-sort ds-5M :timestamp)
+  (bench-sort ds-50M :timestamp)
+
+
+  )


### PR DESCRIPTION
## Parquet sink reliability, observability, and shutdown correctness

This branch hardens the Kafka → Parquet sink component for production use. The changes fall into four areas:

### Prometheus instrumentation

Ten new metrics expose the parquet sink's internals at runtime:

| Metric | Type | Description |
|--------|------|-------------|
| `records_exported` | counter (by topic) | Records successfully written to parquet |
| `parquet_files_written` | counter (by topic) | Files successfully persisted to storage |
| `records_dropped` | counter (by topic) | Records skipped due to conversion failure |
| `datasets_in_progress` | gauge | Datasets currently accumulating |
| `records_in_progress` | gauge | Records across all in-progress datasets |
| `export_retries` | counter (by topic) | Export attempts that triggered a retry |
| `export_critical_failure` | counter (by topic) | CRITICAL: sink shut down after exhausted retries |
| `export_write_duration_secs` | summary (by topic) | Time to write one parquet file (excludes sort) |
| `export_sort_duration_secs` | summary (by topic) | Time to sort a dataset before export |
| `accumulation_age_secs` | summary (by topic) | How long a dataset accumulated before flush |
| `incoming_batch_size` | summary | Messages per batch delivered to the collector |

### Graceful shutdown and correct offset commits

Previously the sink used Kafka auto-commit, meaning offsets could be committed before the corresponding parquet files were safely written to S3. The new design:

- **Disables auto-commit** on the sink's Kafka consumer.
- Introduces a `commit-ch` channel. Offset commit maps are placed on this channel **only after all parquet files for a flush have been successfully written**.
- A `IPostConsumeHook` drains the channel after each poll cycle and calls `commitSync` with the exact offsets that were exported.
- On **critical failure** (all retries exhausted), the sink closes `incoming-msgs-ch` and halts the consumer without committing offsets. Kafka will replay the un-committed messages on the next restart, preventing data loss.
- A `consumer-volatile` + `compare-and-set!` guard makes `halt-consumer!` idempotent, preventing a race between normal shutdown and failure-triggered shutdown.

### Retry tuning

- Max retries increased from **5 → 12** (worst-case ~5 minutes total), enough to survive S3 `SlowDown` / 503 throttle events.
- Exponential backoff now includes **±20% jitter** and is capped at **30 s** per attempt.

### State model restructuring

Accumulator state was reorganised from a flat `{partition → state}` map to a two-level `{topic → {:datasets {partition → dataset}, :partition-offsets {partition → offset}, …}}` shape. This makes per-topic offset tracking explicit and enables correct `commitSync` calls keyed by `TopicPartition`.

---

### Other changes

**`kafka.clj` — ktable catch-up fix**  
Fixed a condition in `ktable-wait-for-catchup` that incorrectly required `ktable-progress-offset` to be non-nil before checking whether the consumer had caught up. Partitions with no prior progress now correctly register as _not yet caught up_.

**`logging.clj` — in-memory log tap**  
Added `install-log-tap!` / `log-tap-entries` / `uninstall-log-tap!` — a global ring-buffer Timbre appender useful for intercepting log output in tests or REPL sessions without requiring a separate log sink.

**`checkpoint_storage/stores.clj` — chunked S3 download (inactive)**  
Added `open-s3-download-stream`, which fetches an S3 object in range-request chunks via a `PipedInputStream`, overlapping network I/O with the caller's reads. This is not wired into any active code path yet; it is present for evaluation and benchmarking against the existing single-request approach.

**`kafka/utilities.clj` — structured logging cleanup**  
Replaced ad-hoc log strings and stray `tap>` calls in the `consume-until-*` / `to-timestamp` strategies with structured `log/trace` and `log/debug` calls carrying labelled maps.

**Dependencies and tooling**  
Added Martian + martian-httpkit to `deps.edn`, updated all library versions, added a `.dir-locals.el` for the `:repl` alias in Emacs, and added a `src/dev/test_ds.clj` scratch file for benchmarking parallel vs sequential parquet sort performance.
