### PR TITLE
allow afrolabs.config/read-parameter-sources to accept no parameters

### DIFF
--- a/src/afrolabs/config.clj
+++ b/src/afrolabs/config.clj
@@ -179,10 +179,11 @@
                                                 (read-system-props))))
 
 (defn read-parameter-sources
-  [dotenv-file]
-  (merge @static-parameter-sources
-         (if-not dotenv-file {}
-                 (read-dotenv-file dotenv-file))))
+  ([] (read-parameter-sources nil))
+  ([dotenv-file]
+   (merge @static-parameter-sources
+          (if-not dotenv-file {}
+                  (read-dotenv-file dotenv-file)))))
 
 (defn read-config
   [config-file-location


### PR DESCRIPTION
This updates a utility function in the config namespace to accept a no-arg overload, so that all parameters in env-vars and system properties can be accessed.